### PR TITLE
Review: Don't add ftrack family 

### DIFF
--- a/client/ayon_harmony/plugins/publish/collect_instances.py
+++ b/client/ayon_harmony/plugins/publish/collect_instances.py
@@ -20,9 +20,9 @@ class CollectInstances(pyblish.api.ContextPlugin):
     order = pyblish.api.CollectorOrder
     hosts = ["harmony"]
     product_type_mapping = {
-        "render": ["review", "ftrack"],
+        "render": ["review"],
         "harmony.template": [],
-        "palette": ["palette", "ftrack"]
+        "palette": ["palette"]
     }
 
     pair_media = True
@@ -70,7 +70,7 @@ class CollectInstances(pyblish.api.ContextPlugin):
             families.extend(self.product_type_mapping[product_type])
             instance.data["families"] = families
 
-            # If set in plugin, pair the scene Version in ftrack with
+            # If set in plugin, pair the scene Version with
             # thumbnails and review media.
             if (self.pair_media and product_type == "scene"):
                 context.data["scene_instance"] = instance

--- a/client/ayon_harmony/plugins/publish/validate_scene_settings.py
+++ b/client/ayon_harmony/plugins/publish/validate_scene_settings.py
@@ -99,7 +99,7 @@ class ValidateSceneSettings(pyblish.api.InstancePlugin):
             expected_settings.pop('frameStartHandle', None)
             expected_settings.pop('frameEndHandle', None)
 
-        # handle case where ftrack uses only two decimal places
+        # handle case when fps uses only two decimal places
         # 23.976023976023978 vs. 23.98
         fps = instance.context.data.get("frameRate")
         if isinstance(instance.context.data.get("frameRate"), float):


### PR DESCRIPTION
## Changelog Description
Do not add ftrack family to review instance automatically.

## Additional info
It is job of ftrack addon to care about it.

## Testing notes:
1. Create package, upload to server, add to bundle (with ftrack addon).
2. Review should go to ftrack.
