### PR TITLE
Refactor legacy `avalon` and `pype` to `AYON`

### DIFF
--- a/client/ayon_harmony/api/README.md
+++ b/client/ayon_harmony/api/README.md
@@ -579,7 +579,7 @@ replace_files = """function %s_replace_files(args)
 
 class ImageSequenceLoader(load.LoaderPlugin):
     """Load images
-    Stores the imported asset in a container named after the asset.
+    Stores the imported product in a container named after the product.
     """
     product_types = {
         "shot",

--- a/client/ayon_harmony/api/README.md
+++ b/client/ayon_harmony/api/README.md
@@ -48,7 +48,7 @@ The integration creates an `AYON` menu entry where all related tools are located
 
 ### Work files
 
-Because Harmony projects are directories, this integration uses `.zip` as work file extension. Internally the project directories are stored under `[User]/.ayon/harmony`. Whenever the user saves the `.xstage` file, the integration zips up the project directory and moves it to the Avalon project path. Zipping and moving happens in the background.
+Because Harmony projects are directories, this integration uses `.zip` as work file extension. Internally the project directories are stored under `[User]/.ayon/harmony`. Whenever the user saves the `.xstage` file, the integration zips up the project directory and moves it to the AYON project path. Zipping and moving happens in the background.
 
 ### Show Workfiles on launch
 

--- a/client/ayon_harmony/api/README.md
+++ b/client/ayon_harmony/api/README.md
@@ -42,13 +42,13 @@ First two bytes are *magic* bytes stands for **A**valon **H**armony. Next four b
 
 ## Usage
 
-The integration creates an `Openpype` menu entry where all related tools are located.
+The integration creates an `AYON` menu entry where all related tools are located.
 
 **NOTE: Menu creation can be temperamental. The best way is to launch Harmony and do nothing else until Harmony is fully launched.**
 
 ### Work files
 
-Because Harmony projects are directories, this integration uses `.zip` as work file extension. Internally the project directories are stored under `[User]/.avalon/harmony`. Whenever the user saves the `.xstage` file, the integration zips up the project directory and moves it to the Avalon project path. Zipping and moving happens in the background.
+Because Harmony projects are directories, this integration uses `.zip` as work file extension. Internally the project directories are stored under `[User]/.ayon/harmony`. Whenever the user saves the `.xstage` file, the integration zips up the project directory and moves it to the Avalon project path. Zipping and moving happens in the background.
 
 ### Show Workfiles on launch
 
@@ -94,20 +94,20 @@ print(harmony.send({"function": func, "args": ["Hello", "Python"]})["result"])
 
 When naming your functions be aware that they are executed in global scope. They can potentially clash with Harmony own function and object names.
 For example `func` is already existing Harmony object. When you call your function `func` it will overwrite in global scope the one from Harmony, causing
-erratic behavior of Harmony. Openpype is prefixing those function names with [UUID4](https://docs.python.org/3/library/uuid.html) making chance of such clash minimal.
+erratic behavior of Harmony. AYON is prefixing those function names with [UUID4](https://docs.python.org/3/library/uuid.html) making chance of such clash minimal.
 See above examples how that works. This will result in function named `38dfcef0_a6d7_4064_8069_51fe99ab276e_hello()`.
 You can find list of Harmony object and function in Harmony documentation.
 
 ### Higher level (recommended)
 
-Instead of sending functions directly to Harmony, it is more efficient and safe to just add your code to `js/PypeHarmony.js` or utilize `{"script": "..."}` method.
+Instead of sending functions directly to Harmony, it is more efficient and safe to just add your code to `js/AyonHarmony.js` or utilize `{"script": "..."}` method.
 
-#### Extending PypeHarmony.js
+#### Extending AyonHarmony.js
 
-Add your function to `PypeHarmony.js`. For example:
+Add your function to `AyonHarmony.js`. For example:
 
 ```javascript
-PypeHarmony.myAwesomeFunction = function() {
+AyonHarmony.myAwesomeFunction = function() {
   someCoolStuff();
 };
 ```
@@ -116,7 +116,7 @@ Then you can call that javascript code from your Python like:
 ```Python
 import ayon_harmony.api as harmony
 
-harmony.send({"function": "PypeHarmony.myAwesomeFunction"});
+harmony.send({"function": "AyonHarmony.myAwesomeFunction"});
 
 ```
 
@@ -185,7 +185,7 @@ harmony.save_scene()
 <details>
   <summary>Click to expand for details on scene save.</summary>
 
-  Because Openpype tools does not deal well with folders for a single entity like a Harmony scene, this integration has implemented to use zip files to encapsulate the Harmony scene folders. Saving scene in Harmony via menu or CTRL+S will not result in producing zip file, only saving it from Workfiles will. This is because
+  Because AYON tools do not deal well with folders for a single entity like a Harmony scene, this integration has implemented to use zip files to encapsulate the Harmony scene folders. Saving scene in Harmony via menu or CTRL+S will not result in producing zip file, only saving it from Workfiles will. This is because
   zipping process can take some time in which we cannot block user from saving again. If xstage file is changed during zipping process it will produce corrupted zip
   archive.
 </details>
@@ -196,7 +196,6 @@ These plugins were made with the [polly config](https://github.com/mindbender-st
 #### Creator Plugin
 ```python
 import ayon_harmony.api as harmony
-from uuid import uuid4
 
 
 class CreateComposite(harmony.Creator):

--- a/client/ayon_harmony/api/README.md
+++ b/client/ayon_harmony/api/README.md
@@ -37,7 +37,7 @@ Server/client now uses stricter protocol to handle communication. This is necess
 | A | H | 0x00 | 0x00 | 0x00 | 0x00 | ...
 
 ```
-First two bytes are *magic* bytes stands for **A**valon **H**armony. Next four bytes hold length of the message `...` encoded as 32bit unsigned integer. This way we know how many bytes to read from the socket and if we need more or we need to parse multiple messages.
+First two bytes are *magic* bytes stands for **A**yon **H**armony. Next four bytes hold length of the message `...` encoded as 32bit unsigned integer. This way we know how many bytes to read from the socket and if we need more or we need to parse multiple messages.
 
 
 ## Usage

--- a/client/ayon_harmony/api/TB_sceneOpened.js
+++ b/client/ayon_harmony/api/TB_sceneOpened.js
@@ -1,10 +1,10 @@
 /* global QTcpSocket, QByteArray, QDataStream, QTimer, QTextCodec, QIODevice, QApplication, include */
 /* global QTcpSocket, QByteArray, QDataStream, QTimer, QTextCodec, QIODevice, QApplication, include */
 /*
-Avalon Harmony Integration - Client
+AYON Harmony Integration - Client
 -----------------------------------
 
-This script implements client communication with Avalon server to bridge
+This script implements client communication with AYON server to bridge
 gap between Python and QtScript.
 
 */
@@ -342,7 +342,7 @@ function Client() {
 }
 
 /**
- * Entry point, creating Avalon Client.
+ * Entry point, creating AYON Client.
  */
 function start() {
     var self = this;

--- a/client/ayon_harmony/api/TB_sceneOpened.js
+++ b/client/ayon_harmony/api/TB_sceneOpened.js
@@ -380,7 +380,6 @@ function start() {
     if (app.ayonMenu == null) {
         menu = menuBar.addMenu(System.getenv('AYON_MENU_LABEL'));
     }
-    // menu = menuBar.addMenu('Avalon');
 
     /**
      * Show creator

--- a/client/ayon_harmony/api/TB_sceneOpened.js
+++ b/client/ayon_harmony/api/TB_sceneOpened.js
@@ -274,7 +274,7 @@ function Client() {
         self.socket.readyRead.connect(self.onReadyRead);
         var app = QCoreApplication.instance();
 
-        app.avalonClient.send(
+        app.ayonClient.send(
             {
                 'module': 'ayon_core.lib',
                 'method': 'emit_event',
@@ -354,9 +354,9 @@ function start() {
     // Attach the client to the QApplication to preserve.
     var app = QCoreApplication.instance();
 
-    if (app.avalonClient == null) {
-        app.avalonClient = new Client();
-        app.avalonClient.socket.connectToHost(host, port);
+    if (app.ayonClient == null) {
+        app.ayonClient = new Client();
+        app.ayonClient.socket.connectToHost(host, port);
     }
     var mainWindow = null;
     var widgets = QApplication.topLevelWidgets();
@@ -367,17 +367,17 @@ function start() {
     }
     var menuBar = mainWindow.menuBar();
     var actions = menuBar.actions();
-    app.avalonMenu = null;
+    app.ayonMenu = null;
 
     for (var i = 0 ; i < actions.length; i++) {
         label = System.getenv('AYON_MENU_LABEL');
         if (actions[i].text == label) {
-            app.avalonMenu = true;
+            app.ayonMenu = true;
         }
     }
 
     var menu = null;
-    if (app.avalonMenu == null) {
+    if (app.ayonMenu == null) {
         menu = menuBar.addMenu(System.getenv('AYON_MENU_LABEL'));
     }
     // menu = menuBar.addMenu('Avalon');
@@ -386,7 +386,7 @@ function start() {
      * Show creator
      */
     self.onCreator = function() {
-        app.avalonClient.send({
+        app.ayonClient.send({
             'module': 'ayon_harmony.api.lib',
             'method': 'show',
             'args': ['creator']
@@ -401,13 +401,13 @@ function start() {
      * Show Workfiles
      */
     self.onWorkfiles = function() {
-        app.avalonClient.send({
+        app.ayonClient.send({
             'module': 'ayon_harmony.api.lib',
             'method': 'show',
             'args': ['workfiles']
         }, false);
     };
-    if (app.avalonMenu == null) {
+    if (app.ayonMenu == null) {
         action = menu.addAction('Workfiles...');
         action.triggered.connect(self.onWorkfiles);
     }
@@ -416,14 +416,14 @@ function start() {
      * Show Loader
      */
     self.onLoad = function() {
-        app.avalonClient.send({
+        app.ayonClient.send({
             'module': 'ayon_harmony.api.lib',
             'method': 'show',
             'args': ['loader']
         }, false);
     };
     // add Loader item to menu
-    if (app.avalonMenu == null) {
+    if (app.ayonMenu == null) {
         action = menu.addAction('Load...');
         action.triggered.connect(self.onLoad);
     }
@@ -432,14 +432,14 @@ function start() {
      * Show Publisher
      */
     self.onPublish = function() {
-        app.avalonClient.send({
+        app.ayonClient.send({
             'module': 'ayon_harmony.api.lib',
             'method': 'show',
             'args': ['publish']
         }, false);
     };
     // add Publisher item to menu
-    if (app.avalonMenu == null) {
+    if (app.ayonMenu == null) {
         action = menu.addAction('Publish...');
         action.triggered.connect(self.onPublish);
     }
@@ -448,14 +448,14 @@ function start() {
      * Show Scene Manager
      */
     self.onManage = function() {
-        app.avalonClient.send({
+        app.ayonClient.send({
             'module': 'ayon_harmony.api.lib',
             'method': 'show',
             'args': ['sceneinventory']
         }, false);
     };
     // add Scene Manager item to menu
-    if (app.avalonMenu == null) {
+    if (app.ayonMenu == null) {
         action = menu.addAction('Manage...');
         action.triggered.connect(self.onManage);
     }
@@ -464,14 +464,14 @@ function start() {
       * Show Subset Manager
       */
     self.onSubsetManage = function() {
-        app.avalonClient.send({
+        app.ayonClient.send({
             'module': 'ayon_harmony.api.lib',
             'method': 'show',
             'args': ['subsetmanager']
         }, false);
     };
     // add Subset Manager item to menu
-    if (app.avalonMenu == null) {
+    if (app.ayonMenu == null) {
         action = menu.addAction('Subset Manager...');
         action.triggered.connect(self.onSubsetManage);
     }
@@ -480,7 +480,7 @@ function start() {
       * Set scene settings from DB to the scene
       */
     self.onSetSceneSettings = function() {
-          app.avalonClient.send(
+          app.ayonClient.send(
             {
               "module": "ayon_harmony.api",
               "method": "ensure_scene_settings",
@@ -490,7 +490,7 @@ function start() {
           );
     };
     // add Set Scene Settings
-    if (app.avalonMenu == null) {
+    if (app.ayonMenu == null) {
         action = menu.addAction('Set Scene Settings...');
         action.triggered.connect(self.onSetSceneSettings);
     }
@@ -499,14 +499,14 @@ function start() {
       * Show Experimental dialog
       */
     self.onExperimentalTools = function() {
-        app.avalonClient.send({
+        app.ayonClient.send({
             'module': 'ayon_harmony.api.lib',
             'method': 'show',
             'args': ['experimental_tools']
         }, false);
     };
     // add Subset Manager item to menu
-    if (app.avalonMenu == null) {
+    if (app.ayonMenu == null) {
         action = menu.addAction('Experimental Tools...');
         action.triggered.connect(self.onExperimentalTools);
     }
@@ -519,10 +519,10 @@ function start() {
     app.onFileChanged = function(path)
     {
       var app = QCoreApplication.instance();
-      if (app.avalonOnFileChanged){
-        app.avalonClient.send(
+      if (app.ayonOnFileChanged){
+        app.ayonClient.send(
           {
-            'module': 'avalon.harmony.lib',
+            'module': 'ayon.harmony.lib',
             'method': 'on_file_changed',
             'args': [path]
           },
@@ -538,7 +538,7 @@ function start() {
 	scene_path = scene.currentProjectPath() +"/" + scene.currentVersionName() + ".xstage";
 	app.watcher.addPath(scenePath);
 	app.watcher.fileChanged.connect(app.onFileChanged);
-  app.avalonOnFileChanged = true;
+  app.ayonOnFileChanged = true;
   */
     app.onFileChanged = function(path) {
         // empty stub
@@ -548,7 +548,7 @@ function start() {
 
 function ensureSceneSettings() {
   var app = QCoreApplication.instance();
-  app.avalonClient.send(
+  app.ayonClient.send(
     {
       "module": "ayon_harmony.api",
       "method": "ensure_scene_settings",

--- a/client/ayon_harmony/api/__init__.py
+++ b/client/ayon_harmony/api/__init__.py
@@ -17,7 +17,7 @@ from .pipeline import (
     application_launch,
     export_template,
     on_pyblish_instance_toggled,
-    inject_avalon_js,
+    inject_ayon_js,
 )
 
 from .lib import (
@@ -61,7 +61,7 @@ __all__ = [
     "application_launch",
     "export_template",
     "on_pyblish_instance_toggled",
-    "inject_avalon_js",
+    "inject_ayon_js",
 
     # lib
     "launch",

--- a/client/ayon_harmony/api/js/AyonHarmonyAPI.js
+++ b/client/ayon_harmony/api/js/AyonHarmonyAPI.js
@@ -5,9 +5,9 @@
 
 /**
  * @namespace
- * @classdesc AvalonHarmony encapsulate all Avalon related functions.
+ * @classdesc AyonHarmonyAPI encapsulate all Avalon related functions.
  */
-var AvalonHarmony = {};
+var AyonHarmonyAPI = {};
 
 
 /**
@@ -15,8 +15,8 @@ var AvalonHarmony = {};
  * @function
  * @return {object} Scene metadata.
  */
-AvalonHarmony.getSceneData = function() {
-    var metadata = scene.metadata('avalon');
+AyonHarmonyAPI.getSceneData = function() {
+    var metadata = scene.metadata('ayon');
     if (metadata){
         return JSON.parse(metadata.value);
     }else {
@@ -30,9 +30,9 @@ AvalonHarmony.getSceneData = function() {
  * @function
  * @param {object} metadata Object containing metadata.
  */
-AvalonHarmony.setSceneData = function(metadata) {
+AyonHarmonyAPI.setSceneData = function(metadata) {
     scene.setMetadata({
-        'name'       : 'avalon',
+        'name'       : 'ayon',
         'type'       : 'string',
         'creator'    : 'Avalon',
         'version'    : '1.0',
@@ -46,7 +46,7 @@ AvalonHarmony.setSceneData = function(metadata) {
  * @function
  * @return {array} Selected nodes paths.
  */
-AvalonHarmony.getSelectedNodes = function () {
+AyonHarmonyAPI.getSelectedNodes = function () {
     var selectionLength = selection.numberOfNodesSelected();
     var selectedNodes = [];
     for (var i = 0 ; i < selectionLength; i++) {
@@ -61,7 +61,7 @@ AvalonHarmony.getSelectedNodes = function () {
  * @function
  * @param {array} nodes Arrya containing node paths to add to selection.
  */
-AvalonHarmony.selectNodes = function(nodes) {
+AyonHarmonyAPI.selectNodes = function(nodes) {
     selection.clearSelection();
     for (var i = 0 ; i < nodes.length; i++) {
         selection.addNodeToSelection(nodes[i]);
@@ -75,7 +75,7 @@ AvalonHarmony.selectNodes = function(nodes) {
  * @param {string} node Node path.
  * @return {boolean} state
  */
-AvalonHarmony.isEnabled = function(node) {
+AyonHarmonyAPI.isEnabled = function(node) {
     return node.getEnable(node);
 };
 
@@ -86,7 +86,7 @@ AvalonHarmony.isEnabled = function(node) {
  * @param {array} nodes Array of node paths.
  * @return {array} array of boolean states.
  */
-AvalonHarmony.areEnabled = function(nodes) {
+AyonHarmonyAPI.areEnabled = function(nodes) {
     var states = [];
     for (var i = 0 ; i < nodes.length; i++) {
         states.push(node.getEnable(nodes[i]));
@@ -100,7 +100,7 @@ AvalonHarmony.areEnabled = function(nodes) {
  * @function
  * @param {array} args Array of nodes array and states array.
  */
-AvalonHarmony.setState = function(args) {
+AyonHarmonyAPI.setState = function(args) {
     var nodes = args[0];
     var states = args[1];
     // length of both arrays must be equal.
@@ -119,7 +119,7 @@ AvalonHarmony.setState = function(args) {
  * @function
  * @param {array} nodes Array of nodes.
  */
-AvalonHarmony.disableNodes = function(nodes) {
+AyonHarmonyAPI.disableNodes = function(nodes) {
     for (var i = 0 ; i < nodes.length; i++)
     {
         node.setEnable(nodes[i], false);
@@ -132,9 +132,9 @@ AvalonHarmony.disableNodes = function(nodes) {
  * @function
  * @return {string} Scene path.
  */
-AvalonHarmony.saveScene = function() {
+AyonHarmonyAPI.saveScene = function() {
     var app = QCoreApplication.instance();
-    app.avalon_on_file_changed = false;
+    app.ayon_on_file_changed = false;
     scene.saveAll();
     return (
         scene.currentProjectPath() + '/' +
@@ -147,9 +147,9 @@ AvalonHarmony.saveScene = function() {
  * Enable Harmony file-watcher.
  * @function
  */
-AvalonHarmony.enableFileWather = function() {
+AyonHarmonyAPI.enableFileWather = function() {
     var app = QCoreApplication.instance();
-    app.avalon_on_file_changed = true;
+    app.ayon_on_file_changed = true;
 };
 
 
@@ -158,7 +158,7 @@ AvalonHarmony.enableFileWather = function() {
  * @function
  * @param {string} path Path to watch.
  */
-AvalonHarmony.addPathToWatcher = function(path) {
+AyonHarmonyAPI.addPathToWatcher = function(path) {
     var app = QCoreApplication.instance();
     app.watcher.addPath(path);
 };
@@ -169,7 +169,7 @@ AvalonHarmony.addPathToWatcher = function(path) {
  * @function
  * @param {string} node Node path.
  */
-AvalonHarmony.setupNodeForCreator = function(node) {
+AyonHarmonyAPI.setupNodeForCreator = function(node) {
     node.setTextAttr(node, 'COMPOSITE_MODE', 1, 'Pass Through');
 };
 
@@ -180,7 +180,7 @@ AvalonHarmony.setupNodeForCreator = function(node) {
  * @param {string} nodeType Node type.
  * @return {array} Node names.
  */
-AvalonHarmony.getNodesNamesByType = function(nodeType) {
+AyonHarmonyAPI.getNodesNamesByType = function(nodeType) {
     var nodes = node.getNodes(nodeType);
     var nodeNames = [];
     for (var i = 0; i < nodes.length; ++i) {
@@ -204,7 +204,7 @@ AvalonHarmony.getNodesNamesByType = function(nodeType) {
  *  selection
  * ];
  */
-AvalonHarmony.createContainer = function(args) {
+AyonHarmonyAPI.createContainer = function(args) {
     var resultNode = node.add('Top', args[0], args[1], 0, 0, 0);
     if (args.length > 2) {
         node.link(args[2], 0, resultNode, 0, false, true);
@@ -221,6 +221,6 @@ AvalonHarmony.createContainer = function(args) {
  * @function
  * @param {string} node Node path.
  */
-AvalonHarmony.deleteNode = function(_node) {
+AyonHarmonyAPI.deleteNode = function(_node) {
     node.deleteNode(_node, true, true);
 };

--- a/client/ayon_harmony/api/js/AyonHarmonyAPI.js
+++ b/client/ayon_harmony/api/js/AyonHarmonyAPI.js
@@ -1,11 +1,11 @@
 // ***************************************************************************
-// *                        Avalon Harmony Host                                *
+// *                        AYON Harmony Host                                *
 // ***************************************************************************
 
 
 /**
  * @namespace
- * @classdesc AyonHarmonyAPI encapsulate all Avalon related functions.
+ * @classdesc AyonHarmonyAPI encapsulate all AYON related functions.
  */
 var AyonHarmonyAPI = {};
 
@@ -34,7 +34,7 @@ AyonHarmonyAPI.setSceneData = function(metadata) {
     scene.setMetadata({
         'name'       : 'ayon',
         'type'       : 'string',
-        'creator'    : 'Avalon',
+        'creator'    : 'AYON',
         'version'    : '1.0',
         'value'      : JSON.stringify(metadata)
     });

--- a/client/ayon_harmony/api/js/AyonHarmonyAPI.js
+++ b/client/ayon_harmony/api/js/AyonHarmonyAPI.js
@@ -17,6 +17,11 @@ var AyonHarmonyAPI = {};
  */
 AyonHarmonyAPI.getSceneData = function() {
     var metadata = scene.metadata('ayon');
+    if (!metadata) {
+        // Backwards compatibility
+        metadata = scene.metadata('avalon');
+    }
+
     if (metadata){
         return JSON.parse(metadata.value);
     }else {

--- a/client/ayon_harmony/api/js/package.json
+++ b/client/ayon_harmony/api/js/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "avalon-harmony",
+  "name": "ayon-harmony",
   "version": "1.0.0",
   "description": "Avalon Harmony Host integration",
   "keywords": [
@@ -8,7 +8,7 @@
     "pipeline"
   ],
   "license": "MIT",
-  "main": "AvalonHarmony.js",
+  "main": "AyonHarmonyAPI.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/client/ayon_harmony/api/js/package.json
+++ b/client/ayon_harmony/api/js/package.json
@@ -1,9 +1,9 @@
 {
   "name": "ayon-harmony",
   "version": "1.0.0",
-  "description": "Avalon Harmony Host integration",
+  "description": "AYON Harmony Host integration",
   "keywords": [
-    "Avalon",
+    "AYON",
     "Harmony",
     "pipeline"
   ],

--- a/client/ayon_harmony/api/lib.py
+++ b/client/ayon_harmony/api/lib.py
@@ -103,43 +103,43 @@ def main(*subprocess_args):
 
 
 def setup_startup_scripts():
-    """Manages installation of avalon's TB_sceneOpened.js for Harmony launch.
+    """Manages installation of ayon's TB_sceneOpened.js for Harmony launch.
 
     If a studio already has defined "TOONBOOM_GLOBAL_SCRIPT_LOCATION", copies
     the TB_sceneOpened.js to that location if the file is different.
-    Otherwise, will set the env var to point to the avalon/harmony folder.
+    Otherwise, will set the env var to point to the ayon/harmony folder.
 
     Admins should be aware that this will overwrite TB_sceneOpened in the
     "TOONBOOM_GLOBAL_SCRIPT_LOCATION", and that if they want to have additional
     logic, they will need to one of the following:
         * Create a Harmony package to manage startup logic
         * Use TB_sceneOpenedUI.js instead to manage startup logic
-        * Add their startup logic to avalon/harmony/TB_sceneOpened.js
+        * Add their startup logic to ayon/harmony/TB_sceneOpened.js
     """
-    avalon_dcc_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)),
+    ayon_dcc_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)),
                                   "api")
     startup_js = "TB_sceneOpened.js"
 
     if os.getenv("TOONBOOM_GLOBAL_SCRIPT_LOCATION"):
 
-        avalon_harmony_startup = os.path.join(avalon_dcc_dir, startup_js)
+        ayon_harmony_startup = os.path.join(ayon_dcc_dir, startup_js)
 
         env_harmony_startup = os.path.join(
             os.getenv("TOONBOOM_GLOBAL_SCRIPT_LOCATION"), startup_js)
 
-        if not filecmp.cmp(avalon_harmony_startup, env_harmony_startup):
+        if not filecmp.cmp(ayon_harmony_startup, env_harmony_startup):
             try:
-                shutil.copy(avalon_harmony_startup, env_harmony_startup)
+                shutil.copy(ayon_harmony_startup, env_harmony_startup)
             except Exception as e:
                 log.error(e)
                 log.warning(
                     "Failed to copy {0} to {1}! "
                     "Defaulting to Avalon TOONBOOM_GLOBAL_SCRIPT_LOCATION."
-                    .format(avalon_harmony_startup, env_harmony_startup))
+                    .format(ayon_harmony_startup, env_harmony_startup))
 
-                os.environ["TOONBOOM_GLOBAL_SCRIPT_LOCATION"] = avalon_dcc_dir
+                os.environ["TOONBOOM_GLOBAL_SCRIPT_LOCATION"] = ayon_dcc_dir
     else:
-        os.environ["TOONBOOM_GLOBAL_SCRIPT_LOCATION"] = avalon_dcc_dir
+        os.environ["TOONBOOM_GLOBAL_SCRIPT_LOCATION"] = ayon_dcc_dir
 
 
 def check_libs():
@@ -231,7 +231,7 @@ def open_empty_workfile():
 def get_local_harmony_path(filepath):
     """From the provided path get the equivalent local Harmony path."""
     basename = os.path.splitext(os.path.basename(filepath))[0]
-    harmony_path = os.path.join(os.path.expanduser("~"), ".avalon", "harmony")
+    harmony_path = os.path.join(os.path.expanduser("~"), ".ayon", "harmony")
     return os.path.join(harmony_path, basename)
 
 
@@ -414,7 +414,7 @@ def get_scene_data():
     try:
         return send(
             {
-                "function": "AvalonHarmony.getSceneData"
+                "function": "AyonHarmonyAPI.getSceneData"
             })["result"]
     except json.decoder.JSONDecodeError:
         # Means no scene metadata has been made before.
@@ -434,7 +434,7 @@ def set_scene_data(data):
     # Write scene data.
     send(
         {
-            "function": "AvalonHarmony.setSceneData",
+            "function": "AyonHarmonyAPI.setSceneData",
             "args": data
         })
 
@@ -471,7 +471,7 @@ def delete_node(node):
     """ Physically delete node from scene. """
     send(
         {
-            "function": "AvalonHarmony.deleteNode",
+            "function": "AyonHarmonyAPI.deleteNode",
             "args": node
         }
     )
@@ -510,7 +510,7 @@ def maintained_selection():
 
     selected_nodes = send(
         {
-            "function": "AvalonHarmony.getSelectedNodes"
+            "function": "AyonHarmonyAPI.getSelectedNodes"
         })["result"]
 
     try:
@@ -518,7 +518,7 @@ def maintained_selection():
     finally:
         selected_nodes = send(
             {
-                "function": "AvalonHarmony.selectNodes",
+                "function": "AyonHarmonyAPI.selectNodes",
                 "args": selected_nodes
             }
         )
@@ -533,7 +533,7 @@ def select_nodes(nodes):
     """ Selects nodes in Node View """
     _ = send(
         {
-            "function": "AvalonHarmony.selectNodes",
+            "function": "AyonHarmonyAPI.selectNodes",
             "args": nodes
         }
     )
@@ -545,13 +545,13 @@ def maintained_nodes_state(nodes):
     # Collect current state.
     states = send(
         {
-            "function": "AvalonHarmony.areEnabled", "args": nodes
+            "function": "AyonHarmonyAPI.areEnabled", "args": nodes
         })["result"]
 
     # Disable all nodes.
     send(
         {
-            "function": "AvalonHarmony.disableNodes", "args": nodes
+            "function": "AyonHarmonyAPI.disableNodes", "args": nodes
         })
 
     try:
@@ -559,7 +559,7 @@ def maintained_nodes_state(nodes):
     finally:
         send(
             {
-                "function": "AvalonHarmony.setState",
+                "function": "AyonHarmonyAPI.setState",
                 "args": [nodes, states]
             })
 
@@ -576,13 +576,13 @@ def save_scene():
     # Need to turn off the background watcher else the communication with
     # the server gets spammed with two requests at the same time.
     scene_path = send(
-        {"function": "AvalonHarmony.saveScene"})["result"]
+        {"function": "AyonHarmonyAPI.saveScene"})["result"]
 
     # Manually update the remote file.
     on_file_changed(scene_path, threaded=False)
 
     # Re-enable the background watcher.
-    send({"function": "AvalonHarmony.enableFileWather"})
+    send({"function": "AyonHarmonyAPI.enableFileWather"})
 
 
 def save_scene_as(filepath):
@@ -609,7 +609,7 @@ def save_scene_as(filepath):
     ProcessContext.workfile_path = destination
 
     send(
-        {"function": "AvalonHarmony.addPathToWatcher", "args": filepath}
+        {"function": "AyonHarmonyAPI.addPathToWatcher", "args": filepath}
     )
 
 

--- a/client/ayon_harmony/api/lib.py
+++ b/client/ayon_harmony/api/lib.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Utility functions used for Avalon - Harmony integration."""
+"""Utility functions used for AYON - Harmony integration."""
 import platform
 import subprocess
 import threading
@@ -134,7 +134,7 @@ def setup_startup_scripts():
                 log.error(e)
                 log.warning(
                     "Failed to copy {0} to {1}! "
-                    "Defaulting to Avalon TOONBOOM_GLOBAL_SCRIPT_LOCATION."
+                    "Defaulting to AYON TOONBOOM_GLOBAL_SCRIPT_LOCATION."
                     .format(ayon_harmony_startup, env_harmony_startup))
 
                 os.environ["TOONBOOM_GLOBAL_SCRIPT_LOCATION"] = ayon_dcc_dir
@@ -145,7 +145,7 @@ def setup_startup_scripts():
 def check_libs():
     """Check if `OpenHarmony`_ is available.
 
-    Avalon expects either path in `LIB_OPENHARMONY_PATH` or `openHarmony.js`
+    AYON expects either path in `LIB_OPENHARMONY_PATH` or `openHarmony.js`
     present in `TOONBOOM_GLOBAL_SCRIPT_LOCATION`.
 
     Throws:
@@ -282,7 +282,7 @@ def launch_zip_file(filepath):
     if ProcessContext.server:
         ProcessContext.server.stop()
 
-    # Launch Avalon server.
+    # Launch AYON server.
     ProcessContext.server = Server(ProcessContext.port)
     ProcessContext.server.start()
     # thread = threading.Thread(target=self.server.start)
@@ -567,7 +567,7 @@ def maintained_nodes_state(nodes):
 def save_scene():
     """Save the Harmony scene safely.
 
-    The built-in (to Avalon) background zip and moving of the Harmony scene
+    The built-in (to AYON) background zip and moving of the Harmony scene
     folder, interferes with server/client communication by sending two requests
     at the same time. This only happens when sending "scene.saveAll()". This
     method prevents this double request and safely saves the scene.

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -168,8 +168,8 @@ def export_template(backdrops, nodes, filepath):
 
 
 def install():
-    """Install Pype as host config."""
-    print("Installing Pype config ...")
+    """Install AYON Harmony as host config."""
+    print("Installing AYON config ...")
 
     pyblish.api.register_host("harmony")
     pyblish.api.register_plugin_path(PUBLISH_PATH)

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -128,8 +128,8 @@ def check_inventory():
 def application_launch(event):
     """Event that is executed after Harmony is launched."""
     # fills AYON_HARMONY_JS
-    pype_harmony_path = Path(__file__).parent.parent / "js" / "AyonHarmony.js"
-    pype_harmony_js = pype_harmony_path.read_text()
+    ayon_harmony_path = Path(__file__).parent.parent / "js" / "AyonHarmony.js"
+    ayon_harmony_js = ayon_harmony_path.read_text()
 
     # go through js/creators, loaders and publish folders and load all scripts
     script = ""
@@ -139,7 +139,7 @@ def application_launch(event):
             script += child.read_text()
 
     # send scripts to Harmony
-    harmony.send({"script": pype_harmony_js})
+    harmony.send({"script": ayon_harmony_js})
     harmony.send({"script": script})
     inject_ayon_js()
 

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -10,7 +10,7 @@ from ayon_core.pipeline import (
     register_creator_plugin_path,
     deregister_loader_plugin_path,
     deregister_creator_plugin_path,
-    AVALON_CONTAINER_ID,
+    AYON_CONTAINER_ID,
 )
 from ayon_core.pipeline.load import get_outdated_containers
 from ayon_core.pipeline.context_tools import get_current_folder_entity
@@ -39,7 +39,7 @@ def set_scene_settings(settings):
 
     """
     harmony.send(
-        {"function": "PypeHarmony.setSceneSettings", "args": settings})
+        {"function": "AyonHarmony.setSceneSettings", "args": settings})
 
 
 def get_current_context_settings():
@@ -95,7 +95,7 @@ def ensure_scene_settings():
             msg += f"\n{item}"
 
         harmony.send(
-            {"function": "PypeHarmony.message", "args": msg})
+            {"function": "AyonHarmony.message", "args": msg})
 
     set_scene_settings(valid_settings)
 
@@ -118,17 +118,17 @@ def check_inventory():
             outdated_nodes.append(
                 harmony.find_node_by_name(container["name"], "READ")
             )
-    harmony.send({"function": "PypeHarmony.setColor", "args": outdated_nodes})
+    harmony.send({"function": "AyonHarmony.setColor", "args": outdated_nodes})
 
     # Warn about outdated containers.
     msg = "There are outdated containers in the scene."
-    harmony.send({"function": "PypeHarmony.message", "args": msg})
+    harmony.send({"function": "AyonHarmony.message", "args": msg})
 
 
 def application_launch(event):
     """Event that is executed after Harmony is launched."""
     # fills AYON_HARMONY_JS
-    pype_harmony_path = Path(__file__).parent.parent / "js" / "PypeHarmony.js"
+    pype_harmony_path = Path(__file__).parent.parent / "js" / "AyonHarmony.js"
     pype_harmony_js = pype_harmony_path.read_text()
 
     # go through js/creators, loaders and publish folders and load all scripts
@@ -141,7 +141,7 @@ def application_launch(event):
     # send scripts to Harmony
     harmony.send({"script": pype_harmony_js})
     harmony.send({"script": script})
-    inject_avalon_js()
+    inject_ayon_js()
 
     # ensure_scene_settings()
     check_inventory()
@@ -157,7 +157,7 @@ def export_template(backdrops, nodes, filepath):
 
     """
     harmony.send({
-        "function": "PypeHarmony.exportTemplate",
+        "function": "AyonHarmony.exportTemplate",
         "args": [
             backdrops,
             nodes,
@@ -200,17 +200,17 @@ def on_pyblish_instance_toggled(instance, old_value, new_value):
     if node:
         harmony.send(
             {
-                "function": "PypeHarmony.toggleInstance",
+                "function": "AyonHarmony.toggleInstance",
                 "args": [node, new_value]
             }
         )
 
 
-def inject_avalon_js():
-    """Inject AvalonHarmony.js into Harmony."""
-    avalon_harmony_js = Path(__file__).parent.joinpath("js/AvalonHarmony.js")
-    script = avalon_harmony_js.read_text()
-    # send AvalonHarmony.js to Harmony
+def inject_ayon_js():
+    """Inject AyonHarmonyAPI.js into Harmony."""
+    ayon_harmony_js = Path(__file__).parent.joinpath("js/AyonHarmonyAPI.js")
+    script = ayon_harmony_js.read_text()
+    # send AyonHarmonyAPI.js to Harmony
     harmony.send({"script": script})
 
 
@@ -333,7 +333,7 @@ def containerise(name,
 
     data = {
         "schema": "openpype:container-2.0",
-        "id": AVALON_CONTAINER_ID,
+        "id": AYON_CONTAINER_ID,
         "name": name,
         "namespace": namespace,
         "loader": str(loader),

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -217,10 +217,6 @@ def inject_ayon_js():
 def ls():
     """Yields containers from Harmony scene.
 
-    This is the host-equivalent of api.ls(), but instead of listing
-    assets on disk, it lists assets already loaded in Harmony; once loaded
-    they are called 'containers'.
-
     Yields:
         dict: container
     """
@@ -315,13 +311,13 @@ def containerise(name,
     """Imprint node with metadata.
 
     Containerisation enables a tracking of version, author and origin
-    for loaded assets.
+    for loaded product representations.
 
     Arguments:
         name (str): Name of resulting assembly.
         namespace (str): Namespace under which to host container.
         node (str): Node to containerise.
-        context (dict): Asset information.
+        context (dict): Loaded representation full context information.
         loader (str, optional): Name of loader used to produce this container.
         suffix (str, optional): Suffix of container, defaults to `_CON`.
 

--- a/client/ayon_harmony/api/plugin.py
+++ b/client/ayon_harmony/api/plugin.py
@@ -22,7 +22,7 @@ class Creator(LegacyCreator):
         """
         harmony.send(
             {
-                "function": "AvalonHarmony.setupNodeForCreator",
+                "function": "AyonHarmonyAPI.setupNodeForCreator",
                 "args": node
             }
         )
@@ -31,7 +31,7 @@ class Creator(LegacyCreator):
         """Plugin entry point."""
         existing_node_names = harmony.send(
             {
-                "function": "AvalonHarmony.getNodesNamesByType",
+                "function": "AyonHarmonyAPI.getNodesNamesByType",
                 "args": self.node_type
             })["result"]
 
@@ -41,7 +41,7 @@ class Creator(LegacyCreator):
             if self.name.lower() == name.lower():
                 harmony.send(
                     {
-                        "function": "AvalonHarmony.message", "args": msg
+                        "function": "AyonHarmonyAPI.message", "args": msg
                     }
                 )
                 return False
@@ -52,14 +52,14 @@ class Creator(LegacyCreator):
             if (self.options or {}).get("useSelection") and selection:
                 node = harmony.send(
                     {
-                        "function": "AvalonHarmony.createContainer",
+                        "function": "AyonHarmonyAPI.createContainer",
                         "args": [self.name, self.node_type, selection[-1]]
                     }
                 )["result"]
             else:
                 node = harmony.send(
                     {
-                        "function": "AvalonHarmony.createContainer",
+                        "function": "AyonHarmonyAPI.createContainer",
                         "args": [self.name, self.node_type]
                     }
                 )["result"]

--- a/client/ayon_harmony/api/workio.py
+++ b/client/ayon_harmony/api/workio.py
@@ -56,7 +56,7 @@ def save_file(filepath):
             temp_path, os.path.basename(temp_path) + ".xstage"
         )
         ProcessContext.server.send(
-            {"function": "AvalonHarmony.addPathToWatcher", "args": scene_path}
+            {"function": "AyonHarmonyAPI.addPathToWatcher", "args": scene_path}
         )
     else:
         os.environ["HARMONY_NEW_WORKFILE_PATH"] = filepath.replace("\\", "/")

--- a/client/ayon_harmony/js/AyonHarmony.js
+++ b/client/ayon_harmony/js/AyonHarmony.js
@@ -11,12 +11,12 @@ LD_OPENHARMONY_PATH = LD_OPENHARMONY_PATH.replace(/\\/g, "/");
 
 /**
  * @namespace
- * @classdesc PypeHarmony encapsulate all Pype related functions.
+ * @classdesc AyonHarmony encapsulate all Pype related functions.
  * @property  {Object}  loaders   Namespace for Loaders JS code.
  * @property  {Object}  Creators  Namespace for Creators JS code.
  * @property  {Object}  Publish   Namespace for Publish plugins JS code.
  */
-var PypeHarmony = {
+var AyonHarmony = {
     Loaders: {},
     Creators: {},
     Publish: {}
@@ -28,7 +28,7 @@ var PypeHarmony = {
  * @function
  * @param {string} message  Argument containing message.
  */
-PypeHarmony.message = function(message) {
+AyonHarmony.message = function(message) {
     MessageBox.information(message);
 };
 
@@ -38,7 +38,7 @@ PypeHarmony.message = function(message) {
  * @function
  * @param {obj} settings  Scene settings.
  */
-PypeHarmony.setSceneSettings = function(settings) {
+AyonHarmony.setSceneSettings = function(settings) {
     if (settings.fps) {
         scene.setFrameRate(settings.fps);
     }
@@ -70,7 +70,7 @@ PypeHarmony.setSceneSettings = function(settings) {
  * @function
  * @return {array} Scene settings.
  */
-PypeHarmony.getSceneSettings = function() {
+AyonHarmony.getSceneSettings = function() {
     return [
         about.getApplicationPath(),
         scene.currentProjectPath(),
@@ -92,9 +92,9 @@ PypeHarmony.getSceneSettings = function() {
  * @param {array} nodes List of nodes.
  * @param {array} rgba  array of RGBA components of color.
  */
-PypeHarmony.setColor = function(nodes, rgba) {
+AyonHarmony.setColor = function(nodes, rgba) {
     for (var i =0; i <= nodes.length - 1; ++i) {
-        var color = PypeHarmony.color(rgba);
+        var color = AyonHarmony.color(rgba);
         node.setColor(nodes[i], color);
     }
 };
@@ -110,7 +110,7 @@ PypeHarmony.setColor = function(nodes, rgba) {
  * var args = [backdrops, nodes, templateFilename, templateDir];
  *
  */
-PypeHarmony.exportTemplate = function(args) {
+AyonHarmony.exportTemplate = function(args) {
     var tempNode = node.add('Top', 'temp_note', 'NOTE', 0, 0, 0);
     var templateGroup = node.createGroup(tempNode, 'temp_group');
     node.deleteNode( templateGroup + '/temp_note' );
@@ -148,7 +148,7 @@ PypeHarmony.exportTemplate = function(args) {
  * @function
  * @param {array} args  Instance name and value.
  */
-PypeHarmony.toggleInstance = function(args) {
+AyonHarmony.toggleInstance = function(args) {
     node.setEnable(args[0], args[1]);
 };
 
@@ -158,7 +158,7 @@ PypeHarmony.toggleInstance = function(args) {
  * @function
  * @param {string} _node  Node name.
  */
-PypeHarmony.deleteNode = function(_node) {
+AyonHarmony.deleteNode = function(_node) {
     node.deleteNode(_node, true, true);
 };
 
@@ -169,7 +169,7 @@ PypeHarmony.deleteNode = function(_node) {
  * @param {string}  src Source file name.
  * @param {string}  dst Destination file name.
  */
-PypeHarmony.copyFile = function(src, dst) {
+AyonHarmony.copyFile = function(src, dst) {
     var srcFile = new PermanentFile(src);
     var dstFile = new PermanentFile(dst);
     srcFile.copy(dstFile);
@@ -182,7 +182,7 @@ PypeHarmony.copyFile = function(src, dst) {
  * @param   {array}     rgba array of rgba values.
  * @return  {ColorRGBA} ColorRGBA Harmony class.
  */
-PypeHarmony.color = function(rgba) {
+AyonHarmony.color = function(rgba) {
     return new ColorRGBA(rgba[0], rgba[1], rgba[2], rgba[3]);
 };
 
@@ -193,7 +193,7 @@ PypeHarmony.color = function(rgba) {
  * @param   {string}  _node node path.
  * @return  {array}   List of dependent nodes.
  */
-PypeHarmony.getDependencies = function(_node) {
+AyonHarmony.getDependencies = function(_node) {
     var target_node = _node;
     var numInput = node.numberOfInputPorts(target_node);
     var dependencies = [];
@@ -209,7 +209,7 @@ PypeHarmony.getDependencies = function(_node) {
  * @function
  * @return  {array} [major_version, minor_version]
  */
-PypeHarmony.getVersion = function() {
+AyonHarmony.getVersion = function() {
     return [
         about.getMajorVersion(),
         about.getMinorVersion()

--- a/client/ayon_harmony/js/AyonHarmony.js
+++ b/client/ayon_harmony/js/AyonHarmony.js
@@ -1,6 +1,6 @@
 /* global include */
 // ***************************************************************************
-// *                        Pype Harmony Host                                *
+// *                        AYON Harmony Host                                *
 // ***************************************************************************
 
 var LD_OPENHARMONY_PATH = System.getenv('LIB_OPENHARMONY_PATH');
@@ -11,7 +11,7 @@ LD_OPENHARMONY_PATH = LD_OPENHARMONY_PATH.replace(/\\/g, "/");
 
 /**
  * @namespace
- * @classdesc AyonHarmony encapsulate all Pype related functions.
+ * @classdesc AyonHarmony encapsulate all AYON related functions.
  * @property  {Object}  loaders   Namespace for Loaders JS code.
  * @property  {Object}  Creators  Namespace for Creators JS code.
  * @property  {Object}  Publish   Namespace for Publish plugins JS code.

--- a/client/ayon_harmony/js/README.md
+++ b/client/ayon_harmony/js/README.md
@@ -1,4 +1,4 @@
-## Pype - ToonBoom Harmony integration
+## AYON - ToonBoom Harmony integration
 
 ### Development
 

--- a/client/ayon_harmony/js/creators/CreateRender.js
+++ b/client/ayon_harmony/js/creators/CreateRender.js
@@ -1,12 +1,12 @@
-/* global PypeHarmony:writable, include */
+/* global AyonHarmony:writable, include */
 // ***************************************************************************
 // *                             CreateRender                                *
 // ***************************************************************************
 
 
-// check if PypeHarmony is defined and if not, load it.
-if (typeof PypeHarmony === 'undefined') {
-    var AYON_HARMONY_JS = System.getenv('AYON_HARMONY_JS') + '/PypeHarmony.js';
+// check if AyonHarmony is defined and if not, load it.
+if (typeof AyonHarmony === 'undefined') {
+    var AYON_HARMONY_JS = System.getenv('AYON_HARMONY_JS') + '/AyonHarmony.js';
     include(AYON_HARMONY_JS.replace(/\\/g, "/"));
 }
 
@@ -30,4 +30,4 @@ CreateRender.prototype.create = function(args) {
 };
 
 // add self to Pype Loaders
-PypeHarmony.Creators.CreateRender = new CreateRender();
+AyonHarmony.Creators.CreateRender = new CreateRender();

--- a/client/ayon_harmony/js/creators/CreateRender.js
+++ b/client/ayon_harmony/js/creators/CreateRender.js
@@ -29,5 +29,5 @@ CreateRender.prototype.create = function(args) {
     node.setTextAttr(args[0], 'MOVIE_PATH', 1, args[1]);
 };
 
-// add self to Pype Loaders
+// add self to AYON Loaders
 AyonHarmony.Creators.CreateRender = new CreateRender();

--- a/client/ayon_harmony/js/loaders/ImageSequenceLoader.js
+++ b/client/ayon_harmony/js/loaders/ImageSequenceLoader.js
@@ -1,11 +1,11 @@
-/* global PypeHarmony:writable, include */
+/* global AyonHarmony:writable, include */
 // ***************************************************************************
 // *                        ImageSequenceLoader                              *
 // ***************************************************************************
 
-// check if PypeHarmony is defined and if not, load it.
-if (typeof PypeHarmony === 'undefined') {
-    var AYON_HARMONY_JS = System.getenv('AYON_HARMONY_JS') + '/PypeHarmony.js';
+// check if AyonHarmony is defined and if not, load it.
+if (typeof AyonHarmony === 'undefined') {
+    var AYON_HARMONY_JS = System.getenv('AYON_HARMONY_JS') + '/AyonHarmony.js';
     include(AYON_HARMONY_JS.replace(/\\/g, "/"));
 }
 
@@ -94,9 +94,9 @@ ImageSequenceLoader.getUniqueColumnName = function(columnPrefix) {
  * ];
  */
 ImageSequenceLoader.prototype.importFiles = function(args) {
-    MessageLog.trace("ImageSequence:: " + typeof PypeHarmony);
+    MessageLog.trace("ImageSequence:: " + typeof AyonHarmony);
     MessageLog.trace("ImageSequence $:: " + typeof $);
-    MessageLog.trace("ImageSequence OH:: " + typeof PypeHarmony.OpenHarmony);
+    MessageLog.trace("ImageSequence OH:: " + typeof AyonHarmony.OpenHarmony);
     var PNGTransparencyMode = 0; // Premultiplied with Black
     var TGATransparencyMode = 0; // Premultiplied with Black
     var SGITransparencyMode = 0; // Premultiplied with Black
@@ -189,7 +189,7 @@ ImageSequenceLoader.prototype.importFiles = function(args) {
         Drawing.create(elemId, 1, true);
         // Get the actual path, in tmp folder.
         drawingFilePath = Drawing.filename(elemId, '1');
-        PypeHarmony.copyFile(files[0], drawingFilePath);
+        AyonHarmony.copyFile(files[0], drawingFilePath);
         // Expose the image for the entire frame range.
         for (var i =0; i <= frame.numberOf() - 1; ++i) {
             timing = startFrame + i;
@@ -203,7 +203,7 @@ ImageSequenceLoader.prototype.importFiles = function(args) {
             Drawing.create(elemId, timing, true);
             // Get the actual path, in tmp folder.
             drawingFilePath = Drawing.filename(elemId, timing.toString());
-            PypeHarmony.copyFile(files[j], drawingFilePath);
+            AyonHarmony.copyFile(files[j], drawingFilePath);
             column.setEntry(uniqueColumnName, 1, timing, timing.toString());
         }
     }
@@ -280,7 +280,7 @@ ImageSequenceLoader.prototype.replaceFiles = function(args) {
         Drawing.create(elemId, 1, true);
         // Get the actual path, in tmp folder.
         drawingFilePath = Drawing.filename(elemId, '1');
-        PypeHarmony.copyFile(files[0], drawingFilePath);
+        AyonHarmony.copyFile(files[0], drawingFilePath);
         MessageLog.trace(files[0]);
         MessageLog.trace(drawingFilePath);
         // Expose the image for the entire frame range.
@@ -296,7 +296,7 @@ ImageSequenceLoader.prototype.replaceFiles = function(args) {
             Drawing.create(elemId, timing, true);
             // Get the actual path, in tmp folder.
             drawingFilePath = Drawing.filename(elemId, timing.toString());
-            PypeHarmony.copyFile( files[l], drawingFilePath );
+            AyonHarmony.copyFile( files[l], drawingFilePath );
             column.setEntry(_column, 1, timing, timing.toString());
         }
     }
@@ -305,4 +305,4 @@ ImageSequenceLoader.prototype.replaceFiles = function(args) {
 };
 
 // add self to Pype Loaders
-PypeHarmony.Loaders.ImageSequenceLoader = new ImageSequenceLoader();
+AyonHarmony.Loaders.ImageSequenceLoader = new ImageSequenceLoader();

--- a/client/ayon_harmony/js/loaders/ImageSequenceLoader.js
+++ b/client/ayon_harmony/js/loaders/ImageSequenceLoader.js
@@ -304,5 +304,5 @@ ImageSequenceLoader.prototype.replaceFiles = function(args) {
     node.setColor(_node, greenColor);
 };
 
-// add self to Pype Loaders
+// add self to AYON Loaders
 AyonHarmony.Loaders.ImageSequenceLoader = new ImageSequenceLoader();

--- a/client/ayon_harmony/js/loaders/TemplateLoader.js
+++ b/client/ayon_harmony/js/loaders/TemplateLoader.js
@@ -175,5 +175,5 @@ TemplateLoader.prototype.askForColumnsUpdate = function() {
         'No'));
 };
 
-// add self to Pype Loaders
+// add self to AYON Loaders
 AyonHarmony.Loaders.TemplateLoader = new TemplateLoader();

--- a/client/ayon_harmony/js/loaders/TemplateLoader.js
+++ b/client/ayon_harmony/js/loaders/TemplateLoader.js
@@ -1,12 +1,12 @@
-/* global PypeHarmony:writable, include */
+/* global AyonHarmony:writable, include */
 // ***************************************************************************
 // *                        TemplateLoader                                   *
 // ***************************************************************************
 
 
-// check if PypeHarmony is defined and if not, load it.
-if (typeof PypeHarmony === 'undefined') {
-    var AYON_HARMONY_JS = System.getenv('AYON_HARMONY_JS') + '/PypeHarmony.js';
+// check if AyonHarmony is defined and if not, load it.
+if (typeof AyonHarmony === 'undefined') {
+    var AYON_HARMONY_JS = System.getenv('AYON_HARMONY_JS') + '/AyonHarmony.js';
     include(AYON_HARMONY_JS.replace(/\\/g, "/"));
 }
 
@@ -176,4 +176,4 @@ TemplateLoader.prototype.askForColumnsUpdate = function() {
 };
 
 // add self to Pype Loaders
-PypeHarmony.Loaders.TemplateLoader = new TemplateLoader();
+AyonHarmony.Loaders.TemplateLoader = new TemplateLoader();

--- a/client/ayon_harmony/js/package.json
+++ b/client/ayon_harmony/js/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "pype-harmony",
+  "name": "ayon-harmony",
   "version": "1.0.0",
-  "description": "Avalon Harmony Host integration",
+  "description": "AYON Harmony Host integration",
   "keywords": [
-    "Pype",
-    "Avalon",
+    "AYON",
+    "Ynput",
     "Harmony",
     "pipeline"
   ],

--- a/client/ayon_harmony/js/package.json
+++ b/client/ayon_harmony/js/package.json
@@ -9,7 +9,7 @@
     "pipeline"
   ],
   "license": "MIT",
-  "main": "PypeHarmony.js",
+  "main": "AyonHarmony.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/client/ayon_harmony/js/publish/CollectCurrentFile.js
+++ b/client/ayon_harmony/js/publish/CollectCurrentFile.js
@@ -24,5 +24,5 @@ CollectCurrentFile.prototype.collect = function() {
     );
 };
 
-// add self to Pype Loaders
+// add self to AYON Loaders
 AyonHarmony.Publish.CollectCurrentFile = new CollectCurrentFile();

--- a/client/ayon_harmony/js/publish/CollectCurrentFile.js
+++ b/client/ayon_harmony/js/publish/CollectCurrentFile.js
@@ -1,12 +1,12 @@
-/* global PypeHarmony:writable, include */
+/* global AyonHarmony:writable, include */
 // ***************************************************************************
 // *                        CollectCurrentFile                               *
 // ***************************************************************************
 
 
-// check if PypeHarmony is defined and if not, load it.
-if (typeof PypeHarmony === 'undefined') {
-    var AYON_HARMONY_JS = System.getenv('AYON_HARMONY_JS') + '/PypeHarmony.js';
+// check if AyonHarmony is defined and if not, load it.
+if (typeof AyonHarmony === 'undefined') {
+    var AYON_HARMONY_JS = System.getenv('AYON_HARMONY_JS') + '/AyonHarmony.js';
     include(AYON_HARMONY_JS.replace(/\\/g, "/"));
 }
 
@@ -25,4 +25,4 @@ CollectCurrentFile.prototype.collect = function() {
 };
 
 // add self to Pype Loaders
-PypeHarmony.Publish.CollectCurrentFile = new CollectCurrentFile();
+AyonHarmony.Publish.CollectCurrentFile = new CollectCurrentFile();

--- a/client/ayon_harmony/js/publish/CollectFarmRender.js
+++ b/client/ayon_harmony/js/publish/CollectFarmRender.js
@@ -1,12 +1,12 @@
-/* global PypeHarmony:writable, include */
+/* global AyonHarmony:writable, include */
 // ***************************************************************************
 // *                        CollectFarmRender                                *
 // ***************************************************************************
 
 
-// check if PypeHarmony is defined and if not, load it.
-if (typeof PypeHarmony === 'undefined') {
-    var AYON_HARMONY_JS = System.getenv('AYON_HARMONY_JS') + '/PypeHarmony.js';
+// check if AyonHarmony is defined and if not, load it.
+if (typeof AyonHarmony === 'undefined') {
+    var AYON_HARMONY_JS = System.getenv('AYON_HARMONY_JS') + '/AyonHarmony.js';
     include(AYON_HARMONY_JS.replace(/\\/g, "/"));
 }
 
@@ -50,4 +50,4 @@ CollectFarmRender.prototype.getRenderNodeSettings = function(n) {
 };
 
 // add self to Pype Loaders
-PypeHarmony.Publish.CollectFarmRender = new CollectFarmRender();
+AyonHarmony.Publish.CollectFarmRender = new CollectFarmRender();

--- a/client/ayon_harmony/js/publish/CollectFarmRender.js
+++ b/client/ayon_harmony/js/publish/CollectFarmRender.js
@@ -49,5 +49,5 @@ CollectFarmRender.prototype.getRenderNodeSettings = function(n) {
     return output;
 };
 
-// add self to Pype Loaders
+// add self to AYON Loaders
 AyonHarmony.Publish.CollectFarmRender = new CollectFarmRender();

--- a/client/ayon_harmony/js/publish/CollectPalettes.js
+++ b/client/ayon_harmony/js/publish/CollectPalettes.js
@@ -29,5 +29,5 @@ CollectPalettes.prototype.getPalettes = function() {
     return palettes;
 };
 
-// add self to Pype Loaders
+// add self to AYON Loaders
 AyonHarmony.Publish.CollectPalettes = new CollectPalettes();

--- a/client/ayon_harmony/js/publish/CollectPalettes.js
+++ b/client/ayon_harmony/js/publish/CollectPalettes.js
@@ -1,12 +1,12 @@
-/* global PypeHarmony:writable, include */
+/* global AyonHarmony:writable, include */
 // ***************************************************************************
 // *                        CollectPalettes                                  *
 // ***************************************************************************
 
 
-// check if PypeHarmony is defined and if not, load it.
-if (typeof PypeHarmony === 'undefined') {
-    var AYON_HARMONY_JS = System.getenv('AYON_HARMONY_JS') + '/PypeHarmony.js';
+// check if AyonHarmony is defined and if not, load it.
+if (typeof AyonHarmony === 'undefined') {
+    var AYON_HARMONY_JS = System.getenv('AYON_HARMONY_JS') + '/AyonHarmony.js';
     include(AYON_HARMONY_JS.replace(/\\/g, "/"));
 }
 
@@ -30,4 +30,4 @@ CollectPalettes.prototype.getPalettes = function() {
 };
 
 // add self to Pype Loaders
-PypeHarmony.Publish.CollectPalettes = new CollectPalettes();
+AyonHarmony.Publish.CollectPalettes = new CollectPalettes();

--- a/client/ayon_harmony/js/publish/ExtractPalette.js
+++ b/client/ayon_harmony/js/publish/ExtractPalette.js
@@ -33,5 +33,5 @@ ExtractPalette.prototype.getPalette = function(paletteId) {
     ];  
 };
 
-// add self to Pype Loaders
+// add self to AYON Loaders
 AyonHarmony.Publish.ExtractPalette = new ExtractPalette();

--- a/client/ayon_harmony/js/publish/ExtractPalette.js
+++ b/client/ayon_harmony/js/publish/ExtractPalette.js
@@ -1,12 +1,12 @@
-/* global PypeHarmony:writable, include */
+/* global AyonHarmony:writable, include */
 // ***************************************************************************
 // *                           ExtractPalette                                *
 // ***************************************************************************
 
 
-// check if PypeHarmony is defined and if not, load it.
-if (typeof PypeHarmony === 'undefined') {
-    var AYON_HARMONY_JS = System.getenv('AYON_HARMONY_JS') + '/PypeHarmony.js';
+// check if AyonHarmony is defined and if not, load it.
+if (typeof AyonHarmony === 'undefined') {
+    var AYON_HARMONY_JS = System.getenv('AYON_HARMONY_JS') + '/AyonHarmony.js';
     include(AYON_HARMONY_JS.replace(/\\/g, "/"));
 }
 
@@ -34,4 +34,4 @@ ExtractPalette.prototype.getPalette = function(paletteId) {
 };
 
 // add self to Pype Loaders
-PypeHarmony.Publish.ExtractPalette = new ExtractPalette();
+AyonHarmony.Publish.ExtractPalette = new ExtractPalette();

--- a/client/ayon_harmony/js/publish/ExtractTemplate.js
+++ b/client/ayon_harmony/js/publish/ExtractTemplate.js
@@ -1,12 +1,12 @@
-/* global PypeHarmony:writable, include */
+/* global AyonHarmony:writable, include */
 // ***************************************************************************
 // *                           ExtractTemplate                               *
 // ***************************************************************************
 
 
-// check if PypeHarmony is defined and if not, load it.
-if (typeof PypeHarmony === 'undefined') {
-    var AYON_HARMONY_JS = System.getenv('AYON_HARMONY_JS') + '/PypeHarmony.js';
+// check if AyonHarmony is defined and if not, load it.
+if (typeof AyonHarmony === 'undefined') {
+    var AYON_HARMONY_JS = System.getenv('AYON_HARMONY_JS') + '/AyonHarmony.js';
     include(AYON_HARMONY_JS.replace(/\\/g, "/"));
 }
 
@@ -51,4 +51,4 @@ ExtractTemplate.prototype.getBackdropsByNode = function(probeNode) {
 };
 
 // add self to Pype Loaders
-PypeHarmony.Publish.ExtractTemplate = new ExtractTemplate();
+AyonHarmony.Publish.ExtractTemplate = new ExtractTemplate();

--- a/client/ayon_harmony/js/publish/ExtractTemplate.js
+++ b/client/ayon_harmony/js/publish/ExtractTemplate.js
@@ -50,5 +50,5 @@ ExtractTemplate.prototype.getBackdropsByNode = function(probeNode) {
     return valid_backdrops;
 };
 
-// add self to Pype Loaders
+// add self to AYON Loaders
 AyonHarmony.Publish.ExtractTemplate = new ExtractTemplate();

--- a/client/ayon_harmony/plugins/create/create_farm_render.py
+++ b/client/ayon_harmony/plugins/create/create_farm_render.py
@@ -21,12 +21,12 @@ class CreateFarmRender(plugin.Creator):
         path = "render/{0}/{0}.".format(node.split("/")[-1])
         harmony.send(
             {
-                "function": "PypeHarmony.Creators.CreateRender.create",
+                "function": "AyonHarmony.Creators.CreateRender.create",
                 "args": [node, path]
             })
         harmony.send(
             {
-                "function": "PypeHarmony.color",
+                "function": "AyonHarmony.color",
                 "args": [[0.9, 0.75, 0.3, 1.0]]
             }
         )

--- a/client/ayon_harmony/plugins/create/create_render.py
+++ b/client/ayon_harmony/plugins/create/create_render.py
@@ -22,6 +22,6 @@ class CreateRender(plugin.Creator):
         path = "render/{0}/{0}.".format(node.split("/")[-1])
         harmony.send(
             {
-                "function": f"PypeHarmony.Creators.{self_name}.create",
+                "function": f"AyonHarmony.Creators.{self_name}.create",
                 "args": [node, path]
             })

--- a/client/ayon_harmony/plugins/load/load_background.py
+++ b/client/ayon_harmony/plugins/load/load_background.py
@@ -231,7 +231,7 @@ replace_files
 
 class BackgroundLoader(load.LoaderPlugin):
     """Load images
-    Stores the imported asset in a container named after the asset.
+    Stores the imported product in a container named after the product.
     """
     product_types = {"background"}
     representations = {"json"}

--- a/client/ayon_harmony/plugins/load/load_imagesequence.py
+++ b/client/ayon_harmony/plugins/load/load_imagesequence.py
@@ -60,7 +60,7 @@ class ImageSequenceLoader(load.LoaderPlugin):
         group_id = str(uuid.uuid4())
         read_node = harmony.send(
             {
-                "function": f"PypeHarmony.Loaders.{self_name}.importFiles",  # noqa: E501
+                "function": f"AyonHarmony.Loaders.{self_name}.importFiles",  # noqa: E501
                 "args": [
                     files,
                     folder_name,
@@ -113,7 +113,7 @@ class ImageSequenceLoader(load.LoaderPlugin):
 
         harmony.send(
             {
-                "function": f"PypeHarmony.Loaders.{self_name}.replaceFiles",
+                "function": f"AyonHarmony.Loaders.{self_name}.replaceFiles",
                 "args": [files, node, 1]
             }
         )
@@ -122,13 +122,13 @@ class ImageSequenceLoader(load.LoaderPlugin):
         if is_representation_from_latest(repre_entity):
             harmony.send(
                 {
-                    "function": "PypeHarmony.setColor",
+                    "function": "AyonHarmony.setColor",
                     "args": [node, [0, 255, 0, 255]]
                 })
         else:
             harmony.send(
                 {
-                    "function": "PypeHarmony.setColor",
+                    "function": "AyonHarmony.setColor",
                     "args": [node, [255, 0, 0, 255]]
                 })
 
@@ -145,7 +145,7 @@ class ImageSequenceLoader(load.LoaderPlugin):
         """
         node = container.get("nodes").pop()
         harmony.send(
-            {"function": "PypeHarmony.deleteNode", "args": [node]}
+            {"function": "AyonHarmony.deleteNode", "args": [node]}
         )
         harmony.imprint(node, {}, remove=True)
 

--- a/client/ayon_harmony/plugins/load/load_imagesequence.py
+++ b/client/ayon_harmony/plugins/load/load_imagesequence.py
@@ -17,7 +17,7 @@ import ayon_harmony.api as harmony
 class ImageSequenceLoader(load.LoaderPlugin):
     """Load image sequences.
 
-    Stores the imported asset in a container named after the asset.
+    Stores the imported product in a container named after the product.
     """
 
     product_types = {

--- a/client/ayon_harmony/plugins/load/load_palette.py
+++ b/client/ayon_harmony/plugins/load/load_palette.py
@@ -52,7 +52,7 @@ class ImportPaletteLoader(load.LoaderPlugin):
 
         harmony.send(
             {
-                "function": "PypeHarmony.message",
+                "function": "AyonHarmony.message",
                 "args": msg
             })
         return name

--- a/client/ayon_harmony/plugins/load/load_template.py
+++ b/client/ayon_harmony/plugins/load/load_template.py
@@ -50,7 +50,7 @@ class TemplateLoader(load.LoaderPlugin):
 
         container_group = harmony.send(
             {
-                "function": f"PypeHarmony.Loaders.{self_name}.loadContainer",
+                "function": f"AyonHarmony.Loaders.{self_name}.loadContainer",
                 "args": [template_path,
                          context["folder"]["name"],
                          context["product"]["name"],
@@ -90,7 +90,7 @@ class TemplateLoader(load.LoaderPlugin):
 
         update_and_replace = harmony.send(
             {
-                "function": f"PypeHarmony.Loaders.{self_name}."
+                "function": f"AyonHarmony.Loaders.{self_name}."
                             "askForColumnsUpdate",
                 "args": []
             }
@@ -100,7 +100,7 @@ class TemplateLoader(load.LoaderPlugin):
             # FIXME: This won't work, need to implement it.
             harmony.send(
                 {
-                    "function": f"PypeHarmony.Loaders.{self_name}."
+                    "function": f"AyonHarmony.Loaders.{self_name}."
                                 "replaceNode",
                     "args": []
                 }
@@ -123,7 +123,7 @@ class TemplateLoader(load.LoaderPlugin):
         """
         node = harmony.find_node_by_name(container["name"], "GROUP")
         harmony.send(
-            {"function": "PypeHarmony.deleteNode", "args": [node]}
+            {"function": "AyonHarmony.deleteNode", "args": [node]}
         )
 
     def switch(self, container, context):
@@ -134,7 +134,7 @@ class TemplateLoader(load.LoaderPlugin):
         """Set node color to green `rgba(0, 255, 0, 255)`."""
         harmony.send(
             {
-                "function": "PypeHarmony.setColor",
+                "function": "AyonHarmony.setColor",
                 "args": [node, [0, 255, 0, 255]]
             })
 
@@ -142,6 +142,6 @@ class TemplateLoader(load.LoaderPlugin):
         """Set node color to red `rgba(255, 0, 0, 255)`."""
         harmony.send(
             {
-                "function": "PypeHarmony.setColor",
+                "function": "AyonHarmony.setColor",
                 "args": [node, [255, 0, 0, 255]]
             })

--- a/client/ayon_harmony/plugins/publish/collect_current_file.py
+++ b/client/ayon_harmony/plugins/publish/collect_current_file.py
@@ -18,5 +18,5 @@ class CollectCurrentFile(pyblish.api.ContextPlugin):
         self_name = self.__class__.__name__
 
         current_file = harmony.send(
-            {"function": f"PypeHarmony.Publish.{self_name}.collect"})["result"]
+            {"function": f"AyonHarmony.Publish.{self_name}.collect"})["result"]
         context.data["currentFile"] = os.path.normpath(current_file)

--- a/client/ayon_harmony/plugins/publish/collect_farm_render.py
+++ b/client/ayon_harmony/plugins/publish/collect_farm_render.py
@@ -58,7 +58,7 @@ class CollectFarmRender(publish.AbstractCollectRender):
         # 0 - filename / 1 - type / 2 - zeros / 3 - start
         info = harmony.send(
             {
-                "function": f"PypeHarmony.Publish.{self_name}."
+                "function": f"AyonHarmony.Publish.{self_name}."
                             "getRenderNodeSettings",
                 "args": node
             })["result"]
@@ -120,7 +120,7 @@ class CollectFarmRender(publish.AbstractCollectRender):
             # 0 - filename / 1 - type / 2 - zeros / 3 - start / 4 - enabled
             info = harmony.send(
                 {
-                    "function": f"PypeHarmony.Publish.{self_name}."
+                    "function": f"AyonHarmony.Publish.{self_name}."
                                 "getRenderNodeSettings",
                     "args": node
                 })["result"]

--- a/client/ayon_harmony/plugins/publish/collect_palettes.py
+++ b/client/ayon_harmony/plugins/publish/collect_palettes.py
@@ -24,7 +24,7 @@ class CollectPalettes(pyblish.api.ContextPlugin):
         self_name = self.__class__.__name__
         palettes = harmony.send(
             {
-                "function": f"PypeHarmony.Publish.{self_name}.getPalettes",
+                "function": f"AyonHarmony.Publish.{self_name}.getPalettes",
             })["result"]
 
         # skip collecting if not in allowed task

--- a/client/ayon_harmony/plugins/publish/collect_scene.py
+++ b/client/ayon_harmony/plugins/publish/collect_scene.py
@@ -17,7 +17,7 @@ class CollectScene(pyblish.api.ContextPlugin):
         """Plugin entry point."""
         result = harmony.send(
             {
-                "function": "PypeHarmony.getSceneSettings",
+                "function": "AyonHarmony.getSceneSettings",
                 "args": []}
         )["result"]
 
@@ -62,7 +62,7 @@ class CollectScene(pyblish.api.ContextPlugin):
 
         result = harmony.send(
             {
-                "function": "PypeHarmony.getVersion",
+                "function": "AyonHarmony.getVersion",
                 "args": []}
         )["result"]
         context.data["harmonyVersion"] = "{}.{}".format(result[0], result[1])

--- a/client/ayon_harmony/plugins/publish/extract_palette.py
+++ b/client/ayon_harmony/plugins/publish/extract_palette.py
@@ -21,7 +21,7 @@ class ExtractPalette(publish.Extractor):
         self_name = self.__class__.__name__
         result = harmony.send(
             {
-                "function": f"PypeHarmony.Publish.{self_name}.getPalette",
+                "function": f"AyonHarmony.Publish.{self_name}.getPalette",
                 "args": instance.data["id"]
             })["result"]
 

--- a/client/ayon_harmony/plugins/publish/extract_palette.py
+++ b/client/ayon_harmony/plugins/publish/extract_palette.py
@@ -147,7 +147,7 @@ class ExtractPalette(publish.Extractor):
                     pixels[i, j] = (255, 255, 255)
 
         draw = ImageDraw.Draw(img)
-        # TODO: This needs to be font included with Pype because
+        # TODO: This needs to be font included with AYON because
         # arial is not available on other platforms then Windows.
         title_font = ImageFont.truetype("arial.ttf", 28)
         label_font = ImageFont.truetype("arial.ttf", 20)

--- a/client/ayon_harmony/plugins/publish/extract_template.py
+++ b/client/ayon_harmony/plugins/publish/extract_template.py
@@ -91,7 +91,7 @@ class ExtractTemplate(publish.Extractor):
         """
         self_name = self.__class__.__name__
         return harmony.send({
-            "function": f"PypeHarmony.Publish.{self_name}.getBackdropsByNode",
+            "function": f"AyonHarmony.Publish.{self_name}.getBackdropsByNode",
             "args": node})["result"]
 
     def get_dependencies(
@@ -110,7 +110,7 @@ class ExtractTemplate(publish.Extractor):
         """
         current_dependencies = harmony.send(
             {
-                "function": "PypeHarmony.getDependencies",
+                "function": "AyonHarmony.getDependencies",
                 "args": node}
         )["result"]
 

--- a/client/ayon_harmony/plugins/publish/validate_scene_settings.py
+++ b/client/ayon_harmony/plugins/publish/validate_scene_settings.py
@@ -45,7 +45,7 @@ class ValidateSceneSettings(pyblish.api.InstancePlugin):
     settings_category = "harmony"
     optional = True
 
-    # skip frameEnd check if asset contains any of:
+    # skip frameEnd check if folder contains any of:
     frame_check_filter = ["_ch_", "_pr_", "_intd_", "_extd_"]  # regex
 
     # skip resolution check if Task name matches any of regex patterns

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -20,7 +20,7 @@ class ValidateAudioPlugin(BaseSettingsModel):
 
 class ValidateSceneSettingsPlugin(BaseSettingsModel):
     """Validate if FrameStart, FrameEnd and Resolution match shot data in DB.
-       Use regular expressions to limit validations only on particular asset
+       Use regular expressions to limit validations only on particular folder
        or task names."""
     _isGroup = True
     enabled: bool = True
@@ -29,7 +29,7 @@ class ValidateSceneSettingsPlugin(BaseSettingsModel):
 
     frame_check_filter: list[str] = SettingsField(
         default_factory=list,
-        title="Skip Frame check for Assets with name containing"
+        title="Skip Frame check for Folder Paths with name containing"
     )
 
     skip_resolution_check: list[str] = SettingsField(


### PR DESCRIPTION
## Changelog Description

Refactor legacy `avalon` and `pype` to `AYON`

## Additional review information

Update all code to refer to `AYON` instead of legacy names.

Fixes #9 

## Testing notes:

1. Harmony launch shoudl work
2. All tools should work
3. Publishing should work

Existing legacy scenes should also still work.
