### PR TITLE
Remove entityType from context settings

### DIFF
--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -60,7 +60,6 @@ def get_current_context_settings():
     handle_end = folder_attributes.get("handleEnd")
     resolution_width = folder_attributes.get("resolutionWidth")
     resolution_height = folder_attributes.get("resolutionHeight")
-    entity_type = folder_attributes.get("entityType")
 
     scene_data = {
         "fps": fps,
@@ -69,8 +68,7 @@ def get_current_context_settings():
         "handleStart": handle_start,
         "handleEnd": handle_end,
         "resolutionWidth": resolution_width,
-        "resolutionHeight": resolution_height,
-        "entityType": entity_type
+        "resolutionHeight": resolution_height
     }
 
     return scene_data

--- a/client/ayon_harmony/plugins/publish/validate_scene_settings.py
+++ b/client/ayon_harmony/plugins/publish/validate_scene_settings.py
@@ -62,7 +62,6 @@ class ValidateSceneSettings(pyblish.api.InstancePlugin):
         #   - the same approach can be used in 'ValidateSceneSettingsRepair'
         expected_settings = harmony.get_current_context_settings()
         self.log.info("scene settings from DB:{}".format(expected_settings))
-        expected_settings.pop("entityType")  # not useful for the validation
 
         expected_settings = _update_frames(dict.copy(expected_settings))
         expected_settings["frameEndHandle"] = expected_settings["frameEnd"] +\


### PR DESCRIPTION
## Changelog Description

Remove entity type - it's unused but causes errors

## Additional review information

Fixes #8

## Testing notes:

1. Setting scene context, publish and validations should still work.