### PR TITLE
Use context settings from task instead of folder entity

### DIFF
--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -13,7 +13,7 @@ from ayon_core.pipeline import (
     AVALON_CONTAINER_ID,
 )
 from ayon_core.pipeline.load import get_outdated_containers
-from ayon_core.pipeline.context_tools import get_current_folder_entity
+from ayon_core.pipeline.context_tools import get_current_task_entity
 
 from ayon_harmony import HARMONY_ADDON_ROOT
 import ayon_harmony.api as harmony
@@ -43,15 +43,15 @@ def set_scene_settings(settings):
 
 
 def get_current_context_settings():
-    """Get settings on current folder from server.
+    """Get settings on current task from server.
 
     Returns:
-        dict: Scene data.
+        dict[str, Any]: Scene data.
 
     """
 
-    folder_entity = get_current_folder_entity()
-    folder_attributes = folder_entity["attrib"]
+    task_entity = get_current_task_entity()
+    folder_attributes = task_entity["attrib"]
 
     fps = folder_attributes.get("fps")
     frame_start = folder_attributes.get("frameStart")

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -51,16 +51,16 @@ def get_current_context_settings():
     """
 
     task_entity = get_current_task_entity()
-    folder_attributes = task_entity["attrib"]
+    task_attributes = task_entity["attrib"]
 
-    fps = folder_attributes.get("fps")
-    frame_start = folder_attributes.get("frameStart")
-    frame_end = folder_attributes.get("frameEnd")
-    handle_start = folder_attributes.get("handleStart")
-    handle_end = folder_attributes.get("handleEnd")
-    resolution_width = folder_attributes.get("resolutionWidth")
-    resolution_height = folder_attributes.get("resolutionHeight")
-    entity_type = folder_attributes.get("entityType")
+    fps = task_attributes.get("fps")
+    frame_start = task_attributes.get("frameStart")
+    frame_end = task_attributes.get("frameEnd")
+    handle_start = task_attributes.get("handleStart")
+    handle_end = task_attributes.get("handleEnd")
+    resolution_width = task_attributes.get("resolutionWidth")
+    resolution_height = task_attributes.get("resolutionHeight")
+    entity_type = task_attributes.get("entityType")
 
     scene_data = {
         "fps": fps,


### PR DESCRIPTION
## Changelog Description

Use context settings from task instead of folder entity

## Additional review information

Now allows to use task level attribute overrides.

## Testing notes:

1. Setting scene context should work.
2. Publishing and validations should work as intended.