### PR TITLE
Refactor Harmony to use the new publisher

### DIFF
--- a/client/ayon_harmony/api/TB_sceneOpened.js
+++ b/client/ayon_harmony/api/TB_sceneOpened.js
@@ -380,7 +380,6 @@ function start() {
     if (app.ayonMenu == null) {
         menu = menuBar.addMenu(System.getenv('AYON_MENU_LABEL'));
     }
-    // menu = menuBar.addMenu('Avalon');
 
     /**
      * Show creator
@@ -395,22 +394,6 @@ function start() {
 
     var action = menu.addAction('Create...');
     action.triggered.connect(self.onCreator);
-
-
-    /**
-     * Show Workfiles
-     */
-    self.onWorkfiles = function() {
-        app.ayonClient.send({
-            'module': 'ayon_harmony.api.lib',
-            'method': 'show',
-            'args': ['workfiles']
-        }, false);
-    };
-    if (app.ayonMenu == null) {
-        action = menu.addAction('Workfiles...');
-        action.triggered.connect(self.onWorkfiles);
-    }
 
     /**
      * Show Loader
@@ -435,7 +418,7 @@ function start() {
         app.ayonClient.send({
             'module': 'ayon_harmony.api.lib',
             'method': 'show',
-            'args': ['publish']
+            'args': ['publisher']
         }, false);
     };
     // add Publisher item to menu
@@ -461,19 +444,19 @@ function start() {
     }
 
     /**
-      * Show Subset Manager
-      */
-    self.onSubsetManage = function() {
+     * Show Workfiles
+     */
+    self.onWorkfiles = function() {
         app.ayonClient.send({
             'module': 'ayon_harmony.api.lib',
             'method': 'show',
-            'args': ['subsetmanager']
+            'args': ['workfiles']
         }, false);
     };
-    // add Subset Manager item to menu
     if (app.ayonMenu == null) {
-        action = menu.addAction('Subset Manager...');
-        action.triggered.connect(self.onSubsetManage);
+        menu.addSeparator();
+        action = menu.addAction('Workfiles...');
+        action.triggered.connect(self.onWorkfiles);
     }
 
      /**
@@ -489,8 +472,10 @@ function start() {
             false
           );
     };
+
     // add Set Scene Settings
     if (app.ayonMenu == null) {
+        menu.addSeparator();
         action = menu.addAction('Set Scene Settings...');
         action.triggered.connect(self.onSetSceneSettings);
     }
@@ -505,8 +490,8 @@ function start() {
             'args': ['experimental_tools']
         }, false);
     };
-    // add Subset Manager item to menu
     if (app.ayonMenu == null) {
+        menu.addSeparator();
         action = menu.addAction('Experimental Tools...');
         action.triggered.connect(self.onExperimentalTools);
     }

--- a/client/ayon_harmony/api/__init__.py
+++ b/client/ayon_harmony/api/__init__.py
@@ -5,7 +5,7 @@ Anything that isn't defined here is INTERNAL and unreliable for external use.
 """
 from .pipeline import (
     ls,
-    install,
+    HarmonyHost,
     list_instances,
     remove_instance,
     select_instance,
@@ -16,7 +16,6 @@ from .pipeline import (
     check_inventory,
     application_launch,
     export_template,
-    on_pyblish_instance_toggled,
     inject_ayon_js,
 )
 
@@ -60,7 +59,6 @@ __all__ = [
     "check_inventory",
     "application_launch",
     "export_template",
-    "on_pyblish_instance_toggled",
     "inject_ayon_js",
 
     # lib

--- a/client/ayon_harmony/api/lib.py
+++ b/client/ayon_harmony/api/lib.py
@@ -186,9 +186,9 @@ def launch(application_path, *args):
 
     """
     from ayon_core.pipeline import install_host
-    from ayon_harmony import api as harmony
+    from ayon_harmony.api import HarmonyHost
 
-    install_host(harmony)
+    install_host(HarmonyHost())
 
     ProcessContext.port = random.randrange(49152, 65535)
     os.environ["AYON_HARMONY_PORT"] = str(ProcessContext.port)
@@ -401,6 +401,11 @@ def show(tool_name):
     kwargs = {}
     if tool_name == "loader":
         kwargs["use_context"] = True
+    elif tool_name == "publisher":
+        kwargs["tab"] = "publish"
+    elif tool_name == "creator":
+        tool_name = "publisher"
+        kwargs["tab"] = "create"
 
     ProcessContext.execute_in_main_thread(
         lambda: host_tools.show_tool_by_name(tool_name, **kwargs)

--- a/client/ayon_harmony/api/plugin.py
+++ b/client/ayon_harmony/api/plugin.py
@@ -10,6 +10,7 @@ class Creator(LegacyCreator):
     If the selection is used, the selected nodes will be connected to the
     created node.
     """
+    # TODO: Refactor to the new creator API
 
     defaults = ["Main"]
     node_type = "COMPOSITE"


### PR DESCRIPTION
## Changelog Description

Refactor Harmony to use the new style publishing system with new publisher UI and the Create Context.

![image](https://github.com/user-attachments/assets/9d5be111-056a-46d7-a791-490ab6705a44)

## Additional review information

- The new publisher UI now opens from the menu entries but is not usable yet.
- This PR targets another branch just so the "diff" is much smaller because it includes all the renaming to `AYON` from #14 as well.

### TODO

- [ ] Refactor to new style creators
- [ ] Implement `HarmonyHost.get_context_data` and `HarmonyHost.update_context_data` methods.

## Testing notes:

1. Harmony should launch as intended
2. Publisher UI should work
3. TODO: New publishing should work
4. TODO: Legacy instances should be able to convert to new publisher instances.