### PR TITLE
No need to publish instances if they are disabled

### DIFF
--- a/client/ayon_harmony/api/server.py
+++ b/client/ayon_harmony/api/server.py
@@ -91,7 +91,6 @@ class Server(threading.Thread):
         """
         current_time = time.time()
         while True:
-            self.log.info("wait ttt")
             # Receive the data in small chunks and retransmit it
             request = None
             try:

--- a/client/ayon_harmony/plugins/publish/collect_farm_render.py
+++ b/client/ayon_harmony/plugins/publish/collect_farm_render.py
@@ -117,6 +117,15 @@ class CollectFarmRender(publish.AbstractCollectRender):
             if product_type != "renderFarm":
                 continue
 
+            # check if node is enabled
+            enabled = harmony.send(
+                {"function": "node.getEnable", "args": [node]})
+            enabled = enabled["result"]
+
+            # Skip disabled nodes.
+            if not enabled:
+                continue
+
             # 0 - filename / 1 - type / 2 - zeros / 3 - start / 4 - enabled
             info = harmony.send(
                 {

--- a/client/ayon_harmony/plugins/publish/collect_instances.py
+++ b/client/ayon_harmony/plugins/publish/collect_instances.py
@@ -59,12 +59,18 @@ class CollectInstances(pyblish.api.ContextPlugin):
             if product_type == "renderFarm":
                 continue
 
+            enabled = harmony.send(
+                {"function": "node.getEnable", "args": [node]})
+            enabled = enabled["result"]
+
+            # Skip disabled nodes.
+            if not enabled:
+                continue
+
             instance = context.create_instance(node.split("/")[-1])
             instance.data.update(data)
             instance.data["setMembers"] = [node]
-            instance.data["publish"] = harmony.send(
-                {"function": "node.getEnable", "args": [node]}
-            )["result"]
+            instance.data["publish"] = enabled
 
             families = [product_type]
             families.extend(self.product_type_mapping[product_type])


### PR DESCRIPTION
Publishing instances does not need to be created if they are disabled

## Test steps:
- disable node in Node view which is also publishing instance
- hit collect publishing instances and see that instance is not collected. 