### PR TITLE
Use Publisher instead of pyblish pype

### DIFF
--- a/client/ayon_harmony/api/TB_sceneOpened.js
+++ b/client/ayon_harmony/api/TB_sceneOpened.js
@@ -380,7 +380,6 @@ function start() {
     if (app.ayonMenu == null) {
         menu = menuBar.addMenu(System.getenv('AYON_MENU_LABEL'));
     }
-    // menu = menuBar.addMenu('Avalon');
 
     /**
      * Show creator
@@ -395,22 +394,6 @@ function start() {
 
     var action = menu.addAction('Create...');
     action.triggered.connect(self.onCreator);
-
-
-    /**
-     * Show Workfiles
-     */
-    self.onWorkfiles = function() {
-        app.ayonClient.send({
-            'module': 'ayon_harmony.api.lib',
-            'method': 'show',
-            'args': ['workfiles']
-        }, false);
-    };
-    if (app.ayonMenu == null) {
-        action = menu.addAction('Workfiles...');
-        action.triggered.connect(self.onWorkfiles);
-    }
 
     /**
      * Show Loader
@@ -435,7 +418,7 @@ function start() {
         app.ayonClient.send({
             'module': 'ayon_harmony.api.lib',
             'method': 'show',
-            'args': ['publish']
+            'args': ['publisher']
         }, false);
     };
     // add Publisher item to menu
@@ -461,19 +444,19 @@ function start() {
     }
 
     /**
-      * Show Subset Manager
-      */
-    self.onSubsetManage = function() {
+     * Show Workfiles
+     */
+    self.onWorkfiles = function() {
         app.ayonClient.send({
             'module': 'ayon_harmony.api.lib',
             'method': 'show',
-            'args': ['subsetmanager']
+            'args': ['workfiles']
         }, false);
     };
-    // add Subset Manager item to menu
     if (app.ayonMenu == null) {
-        action = menu.addAction('Subset Manager...');
-        action.triggered.connect(self.onSubsetManage);
+        menu.addSeparator();
+        action = menu.addAction('Workfiles...');
+        action.triggered.connect(self.onWorkfiles);
     }
 
      /**
@@ -489,8 +472,10 @@ function start() {
             false
           );
     };
+
     // add Set Scene Settings
     if (app.ayonMenu == null) {
+        menu.addSeparator();
         action = menu.addAction('Set Scene Settings...');
         action.triggered.connect(self.onSetSceneSettings);
     }
@@ -505,8 +490,8 @@ function start() {
             'args': ['experimental_tools']
         }, false);
     };
-    // add Subset Manager item to menu
     if (app.ayonMenu == null) {
+        menu.addSeparator();
         action = menu.addAction('Experimental Tools...');
         action.triggered.connect(self.onExperimentalTools);
     }

--- a/client/ayon_harmony/api/__init__.py
+++ b/client/ayon_harmony/api/__init__.py
@@ -48,7 +48,7 @@ from .workio import (
 __all__ = [
     # pipeline
     "ls",
-    "install",
+    "HarmonyHost",
     "list_instances",
     "remove_instance",
     "select_instance",

--- a/client/ayon_harmony/api/__init__.py
+++ b/client/ayon_harmony/api/__init__.py
@@ -5,7 +5,7 @@ Anything that isn't defined here is INTERNAL and unreliable for external use.
 """
 from .pipeline import (
     ls,
-    install,
+    HarmonyHost,
     list_instances,
     remove_instance,
     select_instance,
@@ -16,7 +16,6 @@ from .pipeline import (
     check_inventory,
     application_launch,
     export_template,
-    on_pyblish_instance_toggled,
     inject_ayon_js,
 )
 
@@ -60,7 +59,6 @@ __all__ = [
     "check_inventory",
     "application_launch",
     "export_template",
-    "on_pyblish_instance_toggled",
     "inject_ayon_js",
 
     # lib

--- a/client/ayon_harmony/api/lib.py
+++ b/client/ayon_harmony/api/lib.py
@@ -403,9 +403,6 @@ def show(tool_name):
         kwargs["use_context"] = True
     elif tool_name == "publisher":
         kwargs["tab"] = "publish"
-    elif tool_name == "creator":
-        tool_name = "publisher"
-        kwargs["tab"] = "create"
 
     ProcessContext.execute_in_main_thread(
         lambda: host_tools.show_tool_by_name(tool_name, **kwargs)

--- a/client/ayon_harmony/api/lib.py
+++ b/client/ayon_harmony/api/lib.py
@@ -186,9 +186,9 @@ def launch(application_path, *args):
 
     """
     from ayon_core.pipeline import install_host
-    from ayon_harmony import api as harmony
+    from ayon_harmony.api import HarmonyHost
 
-    install_host(harmony)
+    install_host(HarmonyHost())
 
     ProcessContext.port = random.randrange(49152, 65535)
     os.environ["AYON_HARMONY_PORT"] = str(ProcessContext.port)
@@ -401,6 +401,11 @@ def show(tool_name):
     kwargs = {}
     if tool_name == "loader":
         kwargs["use_context"] = True
+    elif tool_name == "publisher":
+        kwargs["tab"] = "publish"
+    elif tool_name == "creator":
+        tool_name = "publisher"
+        kwargs["tab"] = "create"
 
     ProcessContext.execute_in_main_thread(
         lambda: host_tools.show_tool_by_name(tool_name, **kwargs)

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -42,7 +42,7 @@ CREATE_PATH = os.path.join(PLUGINS_DIR, "create")
 INVENTORY_PATH = os.path.join(PLUGINS_DIR, "inventory")
 
 
-class HarmonyHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
+class HarmonyHost(HostBase, IWorkfileHost, ILoadHost):
     name = "harmony"
 
     def install(self):
@@ -82,11 +82,11 @@ class HarmonyHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
     def get_containers(self):
         return ls()
 
-    def get_context_data(self):
-        raise NotImplementedError()
-
-    def update_context_data(self, data, changes):
-        raise NotImplementedError()
+    # def get_context_data(self):
+    #     raise NotImplementedError()
+    #
+    # def update_context_data(self, data, changes):
+    #     raise NotImplementedError()
 
 
 def set_scene_settings(settings):

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -9,7 +9,6 @@ from ayon_core.host import (
     HostBase,
     IWorkfileHost,
     ILoadHost,
-    IPublishHost,
 )
 from ayon_core.pipeline import (
     register_loader_plugin_path,

--- a/client/ayon_harmony/api/plugin.py
+++ b/client/ayon_harmony/api/plugin.py
@@ -10,6 +10,7 @@ class Creator(LegacyCreator):
     If the selection is used, the selected nodes will be connected to the
     created node.
     """
+    # TODO: Refactor to the new creator API
 
     defaults = ["Main"]
     node_type = "COMPOSITE"


### PR DESCRIPTION
## Changelog Description
This is intermediate step before full conversion to Publisher is finished when AYON legacy Creator is still used and Publisher is used only for publishing because pyblish pype tool does not work with newer Qt releases.

## Additional review information
This might not get merged at all, unless necessary. 
