### PR TITLE
Expose function to locate workdir

### DIFF
--- a/client/ayon_harmony/api/__init__.py
+++ b/client/ayon_harmony/api/__init__.py
@@ -34,7 +34,8 @@ from .lib import (
     find_node_by_name,
     signature,
     select_nodes,
-    get_scene_data
+    get_scene_data,
+    get_workdir
 )
 
 from .workio import (
@@ -78,6 +79,7 @@ __all__ = [
     "signature",
     "select_nodes",
     "get_scene_data",
+    "get_workdir",
 
     # Workfiles API
     "open_file",

--- a/client/ayon_harmony/api/lib.py
+++ b/client/ayon_harmony/api/lib.py
@@ -186,9 +186,9 @@ def launch(application_path, *args):
 
     """
     from ayon_core.pipeline import install_host
-    from ayon_harmony import api as harmony
+    from ayon_harmony.api import HarmonyHost
 
-    install_host(harmony)
+    install_host(HarmonyHost())
 
     ProcessContext.port = random.randrange(49152, 65535)
     os.environ["AYON_HARMONY_PORT"] = str(ProcessContext.port)
@@ -401,6 +401,8 @@ def show(tool_name):
     kwargs = {}
     if tool_name == "loader":
         kwargs["use_context"] = True
+    elif tool_name == "publisher":
+        kwargs["tab"] = "publish"
 
     ProcessContext.execute_in_main_thread(
         lambda: host_tools.show_tool_by_name(tool_name, **kwargs)
@@ -636,3 +638,6 @@ def find_node_by_name(name, node_type):
             return node
 
     return None
+
+def get_workdir():
+    return ProcessContext.workfile_path


### PR DESCRIPTION
## Changelog Description
This is used in Deadline addon (safely) to render to `renders` folder in workdir instead of next to published file.

## Additional review information
Required for https://github.com/ynput/ayon-deadline/pull/91

