### PR TITLE
Return workfile path from harmony host integration

### DIFF
--- a/client/ayon_harmony/api/workio.py
+++ b/client/ayon_harmony/api/workio.py
@@ -70,7 +70,7 @@ def open_file(filepath):
 
 def current_file():
     """Returning None to make Workfiles app look at first file extension."""
-    return None
+    return ProcessContext.workfile_path
 
 
 def work_root(session):


### PR DESCRIPTION
## Changelog Description

Use the by our process context managed `workfile_path` attribute that points to the `.zip` or `None`.

## Additional review information

No idea whether this may introduce issues elsewhere - but it seems to make sense in a way.

## Testing notes:

1. Harmony should work with saving and publishing.
