### PR TITLE
Auto connect to composition node

### DIFF
--- a/client/ayon_harmony/api/js/AyonHarmonyAPI.js
+++ b/client/ayon_harmony/api/js/AyonHarmonyAPI.js
@@ -186,7 +186,7 @@ AyonHarmonyAPI.setupNodeForCreator = function(node) {
  * @return {array} Node names.
  */
 AyonHarmonyAPI.getNodesNamesByType = function(nodeType) {
-    var nodes = node.getNodes(nodeType);
+    var nodes = node.getNodes([nodeType]);
     var nodeNames = [];
     for (var i = 0; i < nodes.length; ++i) {
         nodeNames.push(node.getName(nodes[i]));

--- a/package.py
+++ b/package.py
@@ -1,6 +1,6 @@
 name = "harmony"
 title = "Harmony"
-version = "0.2.2+dev"
+version = "0.2.2+dev.1"
 client_dir = "ayon_harmony"
 app_host_name = "harmony"
 

--- a/server/settings/creator_plugins.py
+++ b/server/settings/creator_plugins.py
@@ -1,0 +1,49 @@
+from ayon_server.settings import BaseSettingsModel, SettingsField
+
+
+class CreateRenderPluginModel(BaseSettingsModel):
+    enabled: bool = SettingsField(True, title="Enabled")
+    active_on_create: bool = SettingsField(True, title="Active by default")
+    default_variants: list[str] = SettingsField(
+        default_factory=list,
+        title="Default Variants"
+    )
+    auto_connect: bool = SettingsField(False, title="Auto connect to node")
+    composition_node_pattern: str = SettingsField(
+        "Composition",
+        title="Auto connect to Composition node",
+        description="Provide regex pattern to find Composition node to connect "
+                    "newly created Write node to. "
+                    "Required for Harmony Advanced without Node View"
+    )
+
+
+class HarmonyCreatePlugins(BaseSettingsModel):
+    CreateRender: CreateRenderPluginModel = SettingsField(
+        title="Render",
+        default_factory=CreateRenderPluginModel,
+    )
+    CreateFarmRender: CreateRenderPluginModel = SettingsField(
+        title="Render on Farm",
+        default_factory=CreateRenderPluginModel,
+    )
+
+
+DEFAULT_CREATE_SETTINGS = {
+    "CreateRender": {
+        "enabled": True,
+        "default_variants": [
+            "Main"
+        ],
+        "auto_connect": False,
+        "composition_node_pattern": "Composition"
+    },
+    "CreateFarmRender": {
+        "enabled": True,
+        "default_variants": [
+            "Main"
+        ],
+        "auto_connect": False,
+        "composition_node_pattern": "Composition"
+    }
+}

--- a/server/settings/creator_plugins.py
+++ b/server/settings/creator_plugins.py
@@ -8,13 +8,12 @@ class CreateRenderPluginModel(BaseSettingsModel):
         default_factory=list,
         title="Default Variants"
     )
-    auto_connect: bool = SettingsField(False, title="Auto connect to node")
+    auto_connect: bool = SettingsField(False,
+                                       title="Auto connect to Composite node")
     composition_node_pattern: str = SettingsField(
         "Composition",
-        title="Auto connect to Composition node",
-        description="Provide regex pattern to find Composition node to connect "
-                    "newly created Write node to. "
-                    "Required for Harmony Advanced without Node View"
+        title="Regex pattern for Composite node name",
+        description="Provide regex pattern to find Composite node to connect newly Write node to"
     )
 
 

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -1,6 +1,7 @@
 from ayon_server.settings import BaseSettingsModel, SettingsField
 
 from .imageio import HarmonyImageIOModel
+from .creator_plugins import HarmonyCreatePlugins
 from .publish_plugins import HarmonyPublishPlugins
 
 
@@ -10,6 +11,10 @@ class HarmonySettings(BaseSettingsModel):
     imageio: HarmonyImageIOModel = SettingsField(
         default_factory=HarmonyImageIOModel,
         title="OCIO config"
+    )
+    create: HarmonyCreatePlugins = SettingsField(
+        default_factory=HarmonyCreatePlugins,
+        title="Creator plugins"
     )
     publish: HarmonyPublishPlugins = SettingsField(
         default_factory=HarmonyPublishPlugins,


### PR DESCRIPTION
## Changelog Description
Supports automatically connecting newly created `Write` node to existing `Composition` mode. This is mostly useful for artists with `Harmony Advanced` where no `Node View` is available (and that way `Use selection` will not work).
Unconnected write node results in blank/black frames.

Added Settings to control this in more detail, provides regex pattern to select `Composite` node more precisely.

## Testing notes:
1. enable `Auto connect to node` 
![image](https://github.com/user-attachments/assets/6c266af4-235f-464a-ae41-31b176319c3b)

2. experiment with disabling `Use selected` and unselecting composition
3. create multiple `Composite` node with unmatching names to 
