### PR TITLE
Fix containers logic failing when `id` key is `None`

### DIFF
--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -15,6 +15,7 @@ from ayon_core.pipeline import (
     register_creator_plugin_path,
     deregister_loader_plugin_path,
     deregister_creator_plugin_path,
+    AVALON_CONTAINER_ID,
     AYON_CONTAINER_ID,
 )
 from ayon_core.pipeline.load import get_outdated_containers
@@ -272,6 +273,11 @@ def inject_ayon_js():
     harmony.send({"script": script})
 
 
+def is_container_data(data: dict) -> bool:
+    """Return whether data is container data."""
+    return data and data.get("id") in {AYON_CONTAINER_ID, AVALON_CONTAINER_ID}
+
+
 def ls():
     """Yields containers from Harmony scene.
 
@@ -280,12 +286,7 @@ def ls():
     """
     objects = harmony.get_scene_data() or {}
     for _, data in objects.items():
-        # Skip non-tagged objects.
-        if not data:
-            continue
-
-        # Filter to only containers.
-        if "container" not in data.get("id", ""):
+        if not is_container_data(data):
             continue
 
         if not data.get("objectName"):  # backward compatibility
@@ -315,7 +316,7 @@ def list_instances(remove_orphaned=True):
             continue
 
         # Filter out containers.
-        if "container" in data.get("id"):
+        if is_container_data(data):
             continue
 
         data['uuid'] = key

--- a/client/ayon_harmony/plugins/publish/collect_farm_render.py
+++ b/client/ayon_harmony/plugins/publish/collect_farm_render.py
@@ -8,6 +8,7 @@ from ayon_core.lib import get_formatted_current_time
 from ayon_core.pipeline import publish
 from ayon_core.pipeline.publish import RenderInstance
 import ayon_harmony.api as harmony
+from ayon_harmony.api.pipeline import is_container_data
 
 
 @attr.s
@@ -108,7 +109,7 @@ class CollectFarmRender(publish.AbstractCollectRender):
                 continue
 
             # Skip containers.
-            if "container" in data["id"]:
+            if is_container_data(data):
                 continue
 
             product_type = data.get("productType")

--- a/client/ayon_harmony/plugins/publish/collect_instances.py
+++ b/client/ayon_harmony/plugins/publish/collect_instances.py
@@ -4,6 +4,7 @@ import json
 
 import pyblish.api
 import ayon_harmony.api as harmony
+from ayon_harmony.api.pipeline import is_container_data
 
 
 class CollectInstances(pyblish.api.ContextPlugin):
@@ -46,7 +47,7 @@ class CollectInstances(pyblish.api.ContextPlugin):
                 continue
 
             # Skip containers.
-            if "container" in data["id"]:
+            if is_container_data(data):
                 continue
 
             product_type = data.get("productType")


### PR DESCRIPTION
## Changelog Description

Do not error on `None` value in `id` metadata if a scene object has that stored

## Additional review information

Fixes error:
```python
Traceback (most recent call last):
  File "C:\Users\jakub\AppData\Local\Ynput\AYON\dependency_packages\ayon_2412190933_windows.zip\dependencies\pyblish\plugin.py", line 528, in __explicit_process
    runner(*args)
  File "C:\CODE\__YNPUT\ayon-core\client\ayon_core\plugins\publish\collect_scene_loaded_versions.py", line 39, in process
    containers = list(host.ls())
  File "C:\CODE\__YNPUT\ayon-harmony\client\ayon_harmony\api\pipeline.py", line 288, in ls
    if "container" not in data.get("id"):
TypeError: argument of type 'NoneType' is not iterable
```

## Testing notes:

_Not sure how to reproduce the 'invalid' object data however._

1. Listing containers (and collecting publish instances) should continue to work
