### PR TITLE
Fix: Template publish error

### DIFF
--- a/client/ayon_harmony/plugins/publish/extract_template.py
+++ b/client/ayon_harmony/plugins/publish/extract_template.py
@@ -60,6 +60,7 @@ class ExtractTemplate(publish.Extractor):
             "zip",
             staging_dir,
         )
+
         representation = {
             "name": "tpl",
             "ext": "zip",

--- a/client/ayon_harmony/plugins/publish/extract_template.py
+++ b/client/ayon_harmony/plugins/publish/extract_template.py
@@ -58,9 +58,9 @@ class ExtractTemplate(publish.Extractor):
         shutil.make_archive(
             f"{instance.name}",
             "zip",
-            os.path.join(staging_dir, f"{instance.name}.tpl")
+            staging_dir,
         )
-
+        
         representation = {
             "name": "tpl",
             "ext": "zip",

--- a/client/ayon_harmony/plugins/publish/extract_template.py
+++ b/client/ayon_harmony/plugins/publish/extract_template.py
@@ -60,7 +60,6 @@ class ExtractTemplate(publish.Extractor):
             "zip",
             staging_dir,
         )
-        
         representation = {
             "name": "tpl",
             "ext": "zip",


### PR DESCRIPTION
## Changelog Description
Fixing template publish error caused by wrong use of `shutil.make_archive`.

## Additional review information
The original error is:
```
Traceback (most recent call last):
  File "/Users/normaal/Documents/rez/packages/build/pyblish_base/1.8.11/6a033ae439b9c3af41025a7f2bc7d5e86c88def5/python/pyblish/plugin.py", line 527, in __explicit_process
    runner(*args)
  File "/Users/normaal/Documents/dev/AYON-Development-Workbench/ayon-harmony/client/ayon_harmony/plugins/publish/extract_template.py", line 58, in process
    shutil.make_archive(
  File "/Users/normaal/Documents/rez/packages/build/python/3.9.18/platform-osx/arch-arm64/lib/python3.9/shutil.py", line 1072, in make_archive
    os.chdir(root_dir)
FileNotFoundError: [Errno 2] No such file or directory: '/var/folders/6g/3800md2j4z5c9lzj6l0z0c5c0000gp/T/ay_tmp_8qh9grit/harmony.templateMain.tpl'
```


## Testing notes:
1. Make a drawing
2. Create a template
3. Publish it
