### PR TITLE
Refactor: Template workflow based on backdrop

### DIFF
--- a/client/ayon_harmony/api/__init__.py
+++ b/client/ayon_harmony/api/__init__.py
@@ -21,7 +21,6 @@ from .pipeline import (
 
 from .lib import (
     launch,
-    maintained_selection,
     imprint,
     read,
     send,
@@ -63,7 +62,6 @@ __all__ = [
 
     # lib
     "launch",
-    "maintained_selection",
     "imprint",
     "read",
     "send",

--- a/client/ayon_harmony/api/__init__.py
+++ b/client/ayon_harmony/api/__init__.py
@@ -15,7 +15,7 @@ from .pipeline import (
     ensure_scene_settings,
     check_inventory,
     application_launch,
-    export_template,
+    export_backdrop_as_template,
     inject_ayon_js,
 )
 
@@ -58,7 +58,7 @@ __all__ = [
     "ensure_scene_settings",
     "check_inventory",
     "application_launch",
-    "export_template",
+    "export_backdrop_as_template",
     "inject_ayon_js",
 
     # lib

--- a/client/ayon_harmony/api/__init__.py
+++ b/client/ayon_harmony/api/__init__.py
@@ -30,6 +30,7 @@ from .lib import (
     remove,
     delete_node,
     find_node_by_name,
+    find_backdrop_by_name,
     signature,
     select_nodes,
     get_scene_data
@@ -71,6 +72,7 @@ __all__ = [
     "remove",
     "delete_node",
     "find_node_by_name",
+    "find_backdrop_by_name",
     "signature",
     "select_nodes",
     "get_scene_data",

--- a/client/ayon_harmony/api/js/AyonHarmonyAPI.js
+++ b/client/ayon_harmony/api/js/AyonHarmonyAPI.js
@@ -196,7 +196,7 @@ AyonHarmonyAPI.getNodesNamesByType = function(nodeType) {
 
 
 /**
- * Create container node in Harmony.
+ * Create container backdrop in Harmony.
  * @function
  * @param {array} args Arguments, see example.
  * @return {string} Resulting node.
@@ -205,19 +205,18 @@ AyonHarmonyAPI.getNodesNamesByType = function(nodeType) {
  * // arguments are in following order:
  * var args = [
  *  nodeName,
- *  nodeType,
  *  selection
  * ];
  */
 AyonHarmonyAPI.createContainer = function(args) {
-    var resultNode = node.add('Top', args[0], args[1], 0, 0, 0);
-    if (args.length > 2) {
-        node.link(args[2], 0, resultNode, 0, false, true);
-        node.setCoord(resultNode,
-            node.coordX(args[2]),
-            node.coordY(args[2]) + 70);
-    }
-    return resultNode;
+    return Backdrop.addBackdrop("Top",
+        {
+            // TODO Find position based on selection?
+            "position"    : {"x": 0, "y" :0, "w":300, "h":300},
+            "title"       : {"text" : args[0], "size" : 14, "font" : "Arial"},
+            // "color"       : TODO
+          }
+    );
 };
 
 

--- a/client/ayon_harmony/api/js/AyonHarmonyAPI.js
+++ b/client/ayon_harmony/api/js/AyonHarmonyAPI.js
@@ -199,24 +199,38 @@ AyonHarmonyAPI.getNodesNamesByType = function(nodeType) {
  * Create container backdrop in Harmony.
  * @function
  * @param {array} args Arguments, see example.
- * @return {string} Resulting node.
+ * @return {string} Resulting backdrop.
  *
  * @example
  * // arguments are in following order:
  * var args = [
- *  nodeName,
- *  selection
+ *  backdropName,
+ *  useSelection
  * ];
  */
 AyonHarmonyAPI.createContainer = function(args) {
-    return Backdrop.addBackdrop("Top",
-        {
-            // TODO Find position based on selection?
-            "position"    : {"x": 0, "y" :0, "w":300, "h":300},
-            "title"       : {"text" : args[0], "size" : 14, "font" : "Arial"},
-            // "color"       : TODO
-          }
-    );
+    var backdropName = args[0];
+    var useSelection = args[1];
+    var selectedBackdrops = selection.selectedBackdrops();
+
+    if (useSelection && selectedBackdrops.length > 0) {
+        // Rename selected backdrop
+        var allBackdrops = Backdrop.backdrops("Top");
+        var selectedBackdropIdx = allBackdrops.map(function(b) { return b.title.text; }).indexOf(selectedBackdrops[0].title.text);
+        allBackdrops[selectedBackdropIdx].title.text = backdropName;
+        Backdrop.setBackdrops("Top", allBackdrops);
+        return allBackdrops[selectedBackdropIdx];
+    } else {
+        // Create new backdrop
+        return Backdrop.addBackdrop(
+            "Top",
+            {
+                "position"    : {"x": 0, "y" :0, "w":300, "h":300},
+                "title"       : {"text" : backdropName, "size" : 14, "font" : "Arial"},
+                // "color"       : TODO
+            }
+        );
+    }
 };
 
 

--- a/client/ayon_harmony/api/lib.py
+++ b/client/ayon_harmony/api/lib.py
@@ -618,3 +618,21 @@ def find_node_by_name(name, node_type):
             return node
 
     return None
+
+def find_backdrop_by_name(name: str) -> dict:
+    """Find backdrop by its name.
+
+    Args:
+        name (str): Name of the backdrop.
+
+    Returns:
+        dict: Backdrop.
+    """
+    backdrops = send(
+        {"function": "Backdrop.backdrops", "args": ["Top"]}
+    )["result"]
+    for backdrop in backdrops:
+        if backdrop["title"]["text"] == name:
+            return backdrop
+
+    return None

--- a/client/ayon_harmony/api/lib.py
+++ b/client/ayon_harmony/api/lib.py
@@ -506,26 +506,6 @@ def imprint(node_id, data, remove=False):
     set_scene_data(scene_data)
 
 
-@contextlib.contextmanager
-def maintained_selection():
-    """Maintain selection during context."""
-
-    selected_nodes = send(
-        {
-            "function": "AyonHarmonyAPI.getSelectedNodes"
-        })["result"]
-
-    try:
-        yield selected_nodes
-    finally:
-        selected_nodes = send(
-            {
-                "function": "AyonHarmonyAPI.selectNodes",
-                "args": selected_nodes
-            }
-        )
-
-
 def send(request):
     """Public method for sending requests to Harmony."""
     return ProcessContext.server.send(request)

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -205,20 +205,17 @@ def application_launch(event):
     check_inventory()
 
 
-def export_template(backdrops, nodes, filepath):
-    """Export Template to file.
+def export_backdrop_as_template(backdrop, filepath):
+    """Export Backdrop as Template (.tpl) file.
 
     Args:
-        backdrops (list): List of backdrops to export.
-        nodes (list): List of nodes to export.
+        backdrop (list): Backdrop to export.
         filepath (str): Path where to save Template.
-
     """
     harmony.send({
         "function": "AyonHarmony.exportTemplate",
         "args": [
-            backdrops,
-            nodes,
+            backdrop,
             os.path.basename(filepath),
             os.path.dirname(filepath)
         ]

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -213,7 +213,7 @@ def export_backdrop_as_template(backdrop, filepath):
         filepath (str): Path where to save Template.
     """
     harmony.send({
-        "function": "AyonHarmony.exportTemplate",
+        "function": "AyonHarmony.exportBackdropAsTemplate",
         "args": [
             backdrop,
             os.path.basename(filepath),

--- a/client/ayon_harmony/api/plugin.py
+++ b/client/ayon_harmony/api/plugin.py
@@ -1,6 +1,4 @@
-import re
-
-from ayon_core.pipeline import LegacyCreator, CreatorError
+from ayon_core.pipeline import LegacyCreator
 import ayon_harmony.api as harmony
 
 

--- a/client/ayon_harmony/api/plugin.py
+++ b/client/ayon_harmony/api/plugin.py
@@ -13,7 +13,7 @@ class Creator(LegacyCreator):
     # TODO: Refactor to the new creator API
 
     defaults = ["Main"]
-    node_type = "COMPOSITE"
+    node_type = "COMPOSITE"  # TODO remove this
     settings_category = "harmony"
 
     auto_connect = False
@@ -51,24 +51,13 @@ class Creator(LegacyCreator):
                 )
                 return False
 
-        with harmony.maintained_selection() as selection:
-            backdrop = None
+        backdrop = harmony.send(
+            {
+                "function": "AyonHarmonyAPI.createContainer",
+                "args": [self.name, (self.options or {}).get("useSelection", False)]
+            }
+        )["result"]
 
-            if (self.options or {}).get("useSelection") and selection:  # TODO use selection
-                backdrop = harmony.send(
-                    {
-                        "function": "AyonHarmonyAPI.createContainer",
-                        "args": [self.name, self.node_type, selection[-1]]
-                    }
-                )["result"]
-            else:
-                backdrop = harmony.send(
-                    {
-                        "function": "AyonHarmonyAPI.createContainer",
-                        "args": [self.name, self.node_type]
-                    }
-                )["result"]
-
-            harmony.imprint(backdrop["title"]["text"], self.data)
+        harmony.imprint(backdrop["title"]["text"], self.data)
 
         return backdrop

--- a/client/ayon_harmony/api/plugin.py
+++ b/client/ayon_harmony/api/plugin.py
@@ -54,51 +54,23 @@ class Creator(LegacyCreator):
                 return False
 
         with harmony.maintained_selection() as selection:
-            node = None
+            backdrop = None
 
-            if (self.options or {}).get("useSelection") and selection:
-                node = harmony.send(
+            if (self.options or {}).get("useSelection") and selection:  # TODO use selection
+                backdrop = harmony.send(
                     {
                         "function": "AyonHarmonyAPI.createContainer",
                         "args": [self.name, self.node_type, selection[-1]]
                     }
                 )["result"]
-            elif (self.auto_connect):
-                    existing_comp_names = harmony.send(
-                    {
-                        "function": "AyonHarmonyAPI.getNodesNamesByType",
-                        "args": "COMPOSITE"
-                    })["result"]
-                    name_pattern = self.composition_node_pattern
-                    if not name_pattern:
-                        raise CreatorError("Composition name regex pattern "
-                                           "must be filled")
-                    compiled_pattern = re.compile(name_pattern)
-                    matching_nodes = [name for name in existing_comp_names
-                                      if compiled_pattern.match(name)]
-                    if len(matching_nodes) > 1:
-                        self.log.warning("Multiple composition node found, "
-                                         "picked first")
-                    elif len(matching_nodes) <= 0:
-                        raise CreatorError("No matching composition "
-                                           "node found")
-                    node_name = f"/Top/{matching_nodes[0]}"
-
-                    node = harmony.send(
-                        {
-                            "function": "AyonHarmonyAPI.createContainer",
-                            "args": [self.name, self.node_type, node_name]
-                        }
-                    )["result"]
             else:
-                node = harmony.send(
+                backdrop = harmony.send(
                     {
                         "function": "AyonHarmonyAPI.createContainer",
                         "args": [self.name, self.node_type]
                     }
                 )["result"]
 
-            harmony.imprint(node, self.data)
-            self.setup_node(node)
+            harmony.imprint(backdrop["title"]["text"], self.data)
 
-        return node
+        return backdrop

--- a/client/ayon_harmony/js/AyonHarmony.js
+++ b/client/ayon_harmony/js/AyonHarmony.js
@@ -107,20 +107,46 @@ AyonHarmony.setColor = function(nodes, rgba) {
  *
  * @example
  * // arguments are in this order:
- * var args = [backdropName, templateFilename, templateDir];
+ * var args = [backdrop, templateFilename, templateDir];
  *
  */
 AyonHarmony.exportBackdropAsTemplate = function(args) {
-    var backdropName = args[0];
+    var backdrop = args[0];
 
-    // Select backdrop and its nodes
-    selection.clearSelection(); // TODO save current selection?
-    selection.addBackdropToSelection(backdropName);
-    selection.addNodesToSelection(Backdrop.nodes(backdropName));
+    // Select backdrop and all nodes in it
+    selection.clearSelection();
+    selection.addBackdropToSelection(backdrop);
+    selection.addNodesToSelection(Backdrop.nodes(backdrop));
+
+    // Select subbackdrops
+    AyonHarmony.getSubBackdrops(backdrop).forEach(function(b) {
+        selection.addBackdropToSelection(b);
+    });
     
     // Export template
     copyPaste.createTemplateFromSelection(args[1], args[2]);
 };
+
+/**
+ * Get subbackdrops of a backdrop.
+ * @function
+ * @param {object} backdrop Backdrop object as described in Backdrop class.
+ * @return {array} List of subbackdrops.
+ */
+AyonHarmony.getSubBackdrops = function(backdrop) {
+    var subBackdrops = [];
+    Backdrop.backdrops(backdrop["group"]).forEach(function(b) {
+        if (b["title"]["text"] != backdrop["title"]["text"]
+            && backdrop["position"]["x"] < b["position"]["x"]
+            && backdrop["position"]["x"] + backdrop["position"]["w"] > b["position"]["x"] + b["position"]["w"]
+            && backdrop["position"]["y"] < b["position"]["y"]
+            && backdrop["position"]["y"] + backdrop["position"]["h"] > b["position"]["y"] + b["position"]["h"]
+        ) {
+            subBackdrops.push(b);
+        }
+    });
+    return subBackdrops;
+}
 
 
 /**

--- a/client/ayon_harmony/js/AyonHarmony.js
+++ b/client/ayon_harmony/js/AyonHarmony.js
@@ -150,6 +150,28 @@ AyonHarmony.getSubBackdrops = function(backdrop) {
 
 
 /**
+ * Remove backdrop and its contents.
+ * @function
+ * @param {string} backdrop Backdrop object.
+ * 
+ */
+AyonHarmony.removeBackdropWithContents = function(backdrop) {
+    // Delete all nodes in backdrop
+    Backdrop.nodes(backdrop).forEach(function(n) {
+        AyonHarmony.deleteNode(n);
+    });
+
+    // Delete subbackdrops
+    AyonHarmony.getSubBackdrops(backdrop).forEach(function(b) {
+        Backdrop.removeBackdrop(b);
+    });
+
+    // Delete backdrop
+    Backdrop.removeBackdrop(backdrop);
+};
+
+
+/**
  * Toggle instance in Harmony.
  * @function
  * @param {array} args  Instance name and value.

--- a/client/ayon_harmony/js/AyonHarmony.js
+++ b/client/ayon_harmony/js/AyonHarmony.js
@@ -101,45 +101,25 @@ AyonHarmony.setColor = function(nodes, rgba) {
 
 
 /**
- * Extract Template into file.
+ * Extract Backdrop as Template file.
  * @function
  * @param {array} args  Arguments for template extraction.
  *
  * @example
  * // arguments are in this order:
- * var args = [backdrops, nodes, templateFilename, templateDir];
+ * var args = [backdropName, templateFilename, templateDir];
  *
  */
-AyonHarmony.exportTemplate = function(args) {
-    var tempNode = node.add('Top', 'temp_note', 'NOTE', 0, 0, 0);
-    var templateGroup = node.createGroup(tempNode, 'temp_group');
-    node.deleteNode( templateGroup + '/temp_note' );
+AyonHarmony.exportBackdropAsTemplate = function(args) {
+    var backdropName = args[0];
 
-    selection.clearSelection();
-    for (var f = 0; f < args[1].length; f++) {
-        selection.addNodeToSelection(args[1][f]);
-    }
-
-    Action.perform('copy()', 'Node View');
-
-    selection.clearSelection();
-    selection.addNodeToSelection(templateGroup);
-    Action.perform('onActionEnterGroup()', 'Node View');
-    Action.perform('paste()', 'Node View');
-
-    // Recreate backdrops in group.
-    for (var i = 0; i < args[0].length; i++) {
-        MessageLog.trace(args[0][i]);
-        Backdrop.addBackdrop(templateGroup, args[0][i]);
-    }
-
-    Action.perform('selectAll()', 'Node View' );
-    copyPaste.createTemplateFromSelection(args[2], args[3]);
-
-    // Unfocus the group in Node view, delete all nodes and backdrops
-    // created during the process.
-    Action.perform('onActionUpToParent()', 'Node View');
-    node.deleteNode(templateGroup, true, true);
+    // Select backdrop and its nodes
+    selection.clearSelection(); // TODO save current selection?
+    selection.addBackdropToSelection(backdropName);
+    selection.addNodesToSelection(Backdrop.nodes(backdropName));
+    
+    // Export template
+    copyPaste.createTemplateFromSelection(args[1], args[2]);
 };
 
 

--- a/client/ayon_harmony/js/loaders/TemplateLoader.js
+++ b/client/ayon_harmony/js/loaders/TemplateLoader.js
@@ -24,59 +24,28 @@ var TemplateLoader = function() {};
  * Load template as container.
  * @function
  * @param {array} args Arguments, see example.
- * @return {string} Name of container.
+ * @return {string} Name of backdrop container.
  *
  * @example
  * // arguments are in following order:
  * var args = [
  *  templatePath, // Path to tpl file.
- *  folderName,    // Folder name.
- *  productName,  // Product name.
- *  groupId       // unique ID (uuid4)
  * ];
  */
 TemplateLoader.prototype.loadContainer = function(args) {
-    var doc = $.scn;
     var templatePath = args[0];
-    var folderName = args[1];
-    var productName = args[2];
-    var groupId = args[3];
 
-    // Get the current group
-    var nodeViewWidget = $.app.getWidgetByName('Node View');
-    if (!nodeViewWidget) {
-        $.alert('You must have a Node View open!', 'No Node View!', 'OK!');
-        return;
-    }
+    // Copy from template file
+    var _copyOptions = copyPaste.getCurrentCreateOptions();
+    var _tpl = copyPaste.copyFromTemplate(templatePath, 0, 999, _copyOptions);
 
-    nodeViewWidget.setFocus();
-    var currentGroup;
-    var nodeView = view.currentView();
-    if (!nodeView) {
-        currentGroup = doc.root;
-    } else {
-        currentGroup = doc.$node(view.group(nodeView));
-    }
+    // Paste into scene
+    var pasteOptions = copyPaste.getCurrentPasteOptions();
+    pasteOptions.extendScene = true; // TODO does this work?
+    copyPaste.pasteNewNodes(_tpl, "Top", pasteOptions);
 
-    // Get a unique iterative name for the container group
-    var num = 0;
-    var containerGroupName = '';
-    do {
-        containerGroupName = folderName + '_' + (num++) + '_' + productName;
-    } while (currentGroup.getNodeByName(containerGroupName) != null);
-
-    // import the template
-    var tplNodes = currentGroup.importTemplate(templatePath);
-    MessageLog.trace(tplNodes);
-    // Create the container group
-    var groupNode = currentGroup.addGroup(
-        containerGroupName, false, false, tplNodes);
-
-    // Add uuid to attribute of the container group
-    node.createDynamicAttr(groupNode, 'STRING', 'uuid', 'uuid', false);
-    node.setTextAttr(groupNode, 'uuid', 1.0, groupId);
-
-    return String(groupNode);
+    // Find backdrop name
+    return selection.selectedBackdrops()[0]["title"]["text"];
 };
 
 

--- a/client/ayon_harmony/js/loaders/TemplateLoader.js
+++ b/client/ayon_harmony/js/loaders/TemplateLoader.js
@@ -23,18 +23,10 @@ var TemplateLoader = function() {};
 /**
  * Load template as container.
  * @function
- * @param {array} args Arguments, see example.
+ * @param {string} templatePath Path to tpl file.
  * @return {string} Name of backdrop container.
- *
- * @example
- * // arguments are in following order:
- * var args = [
- *  templatePath, // Path to tpl file.
- * ];
  */
-TemplateLoader.prototype.loadContainer = function(args) {
-    var templatePath = args[0];
-
+TemplateLoader.prototype.loadContainer = function(templatePath) {
     // Copy from template file
     var _copyOptions = copyPaste.getCurrentCreateOptions();
     var _tpl = copyPaste.copyFromTemplate(templatePath, 0, 999, _copyOptions);
@@ -44,104 +36,19 @@ TemplateLoader.prototype.loadContainer = function(args) {
     pasteOptions.extendScene = true; // TODO does this work?
     copyPaste.pasteNewNodes(_tpl, "Top", pasteOptions);
 
-    // Find backdrop name
-    return selection.selectedBackdrops()[0]["title"]["text"];
-};
-
-
-/**
- * Replace existing node container.
- * @function
- * @param  {string}  dstNodePath Harmony path to destination Node.
- * @param  {string}  srcNodePath Harmony path to source Node.
- * @param  {string}  renameSrc   ...
- * @param  {boolean} cloneSrc    ...
- * @return {boolean}             Success
- * @todo   This is work in progress.
- */
-TemplateLoader.prototype.replaceNode = function(
-    dstNodePath, srcNodePath, renameSrc, cloneSrc) {
-    var doc = $.scn;
-    var srcNode = doc.$node(srcNodePath);
-    var dstNode = doc.$node(dstNodePath);
-    // var dstNodeName = dstNode.name;
-    var replacementNode = srcNode;
-    // var dstGroup = dstNode.group;
-    $.beginUndo();
-    if (cloneSrc) {
-        replacementNode = doc.$node(
-            $.nodeTools.copy_paste_node(
-                srcNodePath, dstNode.name + '_CLONE', dstNode.group.path));
-    } else {
-        if (replacementNode.group.path != srcNode.group.path) {
-            replacementNode.moveToGroup(dstNode);
+    // Find main backdrop name
+    // The main backdrop is the one with the smallest x + y value (top left corner)
+    var selectedBackdrops = selection.selectedBackdrops();
+    var mainBackdropName = selectedBackdrops[0].title.text;
+    var mainAnchorValue = selectedBackdrops[0].position.x + selectedBackdrops[0].position.y;
+    selectedBackdrops.slice(1).forEach(function(backdrop) {
+        var anchor = backdrop.position.x + backdrop.position.y;
+        if (mainAnchorValue > anchor) {
+            mainBackdropName = backdrop.title.text;
+            mainAnchorValue = anchor;
         }
-    }
-    var inLinks = dstNode.getInLinks();
-    var link, inNode, inPort, outPort, outNode, success;
-    for (var l in inLinks) {
-        if (Object.prototype.hasOwnProperty.call(inLinks, l)) {
-            link = inLinks[l];
-            inPort = Number(link.inPort);
-            outPort = Number(link.outPort);
-            outNode = link.outNode;
-            success = replacementNode.linkInNode(outNode, inPort, outPort);
-            if (success) {
-                $.log('Successfully connected ' + outNode + ' : ' +
-            outPort + ' -> ' + replacementNode + ' : ' + inPort);
-            } else {
-                $.alert('Failed to connect ' + outNode + ' : ' +
-            outPort + ' -> ' + replacementNode + ' : ' + inPort);
-            }
-        }
-    }
-
-    var outLinks = dstNode.getOutLinks();
-    for (l in outLinks) {
-        if (Object.prototype.hasOwnProperty.call(outLinks, l)) {
-            link = outLinks[l];
-            inPort = Number(link.inPort);
-            outPort = Number(link.outPort);
-            inNode = link.inNode;
-            // first we must disconnect the port from the node being
-            // replaced to this links inNode port
-            inNode.unlinkInPort(inPort);
-            success = replacementNode.linkOutNode(inNode, outPort, inPort);
-            if (success) {
-                $.log('Successfully connected ' + inNode + ' : ' +
-              inPort + ' <- ' + replacementNode + ' : ' + outPort);
-            } else {
-                if (inNode.type == 'MultiLayerWrite') {
-                    $.log('Attempting standard api to connect the nodes...');
-                    success = node.link(
-                        replacementNode, outPort, inNode,
-                        inPort, node.numberOfInputPorts(inNode) + 1);
-                    if (success) {
-                        $.log('Successfully connected ' + inNode + ' : ' +
-                inPort + ' <- ' + replacementNode + ' : ' + outPort);
-                    }
-                }
-            }
-            if (!success) {
-                $.alert('Failed to connect ' + inNode + ' : ' +
-            inPort + ' <- ' + replacementNode + ' : ' + outPort);
-                return false;
-            }
-        }
-    }
-};
-
-
-TemplateLoader.prototype.askForColumnsUpdate = function() {
-    // Ask user if they want to also update columns and
-    // linked attributes here
-    return ($.confirm(
-        'Would you like to update in place and reconnect all \n' +
-      'ins/outs, attributes, and columns?',
-        'Update & Replace?\n' +
-      'If you choose No, the version will only be loaded.',
-        'Yes',
-        'No'));
+    });
+    return mainBackdropName;
 };
 
 // add self to AYON Loaders

--- a/client/ayon_harmony/plugins/load/load_template.py
+++ b/client/ayon_harmony/plugins/load/load_template.py
@@ -114,16 +114,15 @@ class TemplateLoader(load.LoaderPlugin):
             node, {"representation": repre_entity["id"]}
         )
 
-    def remove(self, container): # TODO: Implement this
+    def remove(self, container):
         """Remove container.
 
         Args:
             container (dict): container definition.
-
         """
-        node = harmony.find_node_by_name(container["name"], "GROUP")
+        backdrop = harmony.find_backdrop_by_name(container["name"])
         harmony.send(
-            {"function": "AyonHarmony.deleteNode", "args": [node]}
+            {"function": "AyonHarmony.removeBackdropWithContents", "args": backdrop}
         )
 
     def switch(self, container, context): # TODO: Implement this

--- a/client/ayon_harmony/plugins/load/load_template.py
+++ b/client/ayon_harmony/plugins/load/load_template.py
@@ -23,7 +23,7 @@ class TemplateLoader(load.LoaderPlugin):
 
     """
 
-    product_types = {"template", "workfile"}
+    product_types = {"harmony.template"}
     representations = {"*"}
     label = "Load Template"
     icon = "gift"
@@ -42,16 +42,16 @@ class TemplateLoader(load.LoaderPlugin):
         self_name = self.__class__.__name__
         temp_dir = tempfile.mkdtemp()
         zip_file = get_representation_path(context["representation"])
-        template_path = os.path.join(temp_dir, "temp.tpl")
+        template_path = os.path.join(temp_dir)
         with zipfile.ZipFile(zip_file, "r") as zip_ref:
             zip_ref.extractall(template_path)
 
         group_id = "{}".format(uuid.uuid4())
 
-        container_group = harmony.send(
+        container_backdrop = harmony.send(
             {
                 "function": f"AyonHarmony.Loaders.{self_name}.loadContainer",
-                "args": [template_path,
+                "args": [os.path.join(template_path, "harmony.tpl"),
                          context["folder"]["name"],
                          context["product"]["name"],
                          group_id]
@@ -65,12 +65,12 @@ class TemplateLoader(load.LoaderPlugin):
         return harmony.containerise(
             name,
             namespace,
-            container_group,
+            container_backdrop,
             context,
             self_name
         )
 
-    def update(self, container, context):
+    def update(self, container, context): # TODO: Implement this
         """Update loaded containers.
 
         Args:
@@ -114,7 +114,7 @@ class TemplateLoader(load.LoaderPlugin):
             node, {"representation": repre_entity["id"]}
         )
 
-    def remove(self, container):
+    def remove(self, container): # TODO: Implement this
         """Remove container.
 
         Args:
@@ -126,11 +126,11 @@ class TemplateLoader(load.LoaderPlugin):
             {"function": "AyonHarmony.deleteNode", "args": [node]}
         )
 
-    def switch(self, container, context):
+    def switch(self, container, context): # TODO: Implement this
         """Switch representation containers."""
         self.update(container, context)
 
-    def _set_green(self, node):
+    def _set_green(self, node): # TODO refactor for backdrop
         """Set node color to green `rgba(0, 255, 0, 255)`."""
         harmony.send(
             {
@@ -138,7 +138,7 @@ class TemplateLoader(load.LoaderPlugin):
                 "args": [node, [0, 255, 0, 255]]
             })
 
-    def _set_red(self, node):
+    def _set_red(self, node): # TODO refactor for backdrop
         """Set node color to red `rgba(255, 0, 0, 255)`."""
         harmony.send(
             {

--- a/client/ayon_harmony/plugins/load/load_template.py
+++ b/client/ayon_harmony/plugins/load/load_template.py
@@ -4,7 +4,6 @@ import tempfile
 import zipfile
 import os
 import shutil
-import uuid
 
 from ayon_core.pipeline import (
     load,
@@ -95,7 +94,7 @@ class TemplateLoader(load.LoaderPlugin):
         # Keep backdrop links
         backdrop_links = harmony.send(
             {
-                "function": f"AyonHarmony.getBackdropLinks",
+                "function": "AyonHarmony.getBackdropLinks",
                 "args": backdrop,
             }
         )["result"]
@@ -107,7 +106,7 @@ class TemplateLoader(load.LoaderPlugin):
         # Restore backdrop links
         harmony.send(
             {
-                "function": f"AyonHarmony.setNodesLinks",
+                "function": "AyonHarmony.setNodesLinks",
                 "args": backdrop_links
             }
         )

--- a/client/ayon_harmony/plugins/load/load_template.py
+++ b/client/ayon_harmony/plugins/load/load_template.py
@@ -9,7 +9,6 @@ from ayon_core.pipeline import (
     load,
     get_representation_path,
 )
-from ayon_core.pipeline.context_tools import is_representation_from_latest
 import ayon_harmony.api as harmony
 
 

--- a/client/ayon_harmony/plugins/publish/collect_instances.py
+++ b/client/ayon_harmony/plugins/publish/collect_instances.py
@@ -34,12 +34,13 @@ class CollectInstances(pyblish.api.ContextPlugin):
             context (:class:`pyblish.api.Context`): Context data.
 
         """
-        nodes = harmony.send(
-            {"function": "node.subNodes", "args": ["Top"]}
+        backdrops = harmony.send(
+            {"function": "Backdrop.backdrops", "args": ["Top"]} # TODO is it possible to have nested containers?
         )["result"]
 
-        for node in nodes:
-            data = harmony.read(node)
+        for backdrop in backdrops:
+            container_name = backdrop["title"]["text"]
+            data = harmony.read(container_name)
 
             # Skip non-tagged nodes.
             if not data:
@@ -59,12 +60,10 @@ class CollectInstances(pyblish.api.ContextPlugin):
             if product_type == "renderFarm":
                 continue
 
-            instance = context.create_instance(node.split("/")[-1])
+            instance = context.create_instance(container_name)
             instance.data.update(data)
-            instance.data["setMembers"] = [node]
-            instance.data["publish"] = harmony.send(
-                {"function": "node.getEnable", "args": [node]}
-            )["result"]
+            instance.data["setMembers"] = [backdrop]
+            # instance.data["publish"] = harmony.send( // TODO base enabling on last composite node state?
 
             families = [product_type]
             families.extend(self.product_type_mapping[product_type])

--- a/client/ayon_harmony/plugins/publish/extract_template.py
+++ b/client/ayon_harmony/plugins/publish/extract_template.py
@@ -17,40 +17,13 @@ class ExtractTemplate(publish.Extractor):
     def process(self, instance):
         """Plugin entry point."""
         staging_dir = self.staging_dir(instance)
-        filepath = os.path.join(staging_dir, f"{instance.name}.tpl")
+        filepath = os.path.join(staging_dir, "harmony", f"{instance.name}.tpl")
 
         self.log.info(f"Outputting template to {staging_dir}")
 
-        dependencies = []
-        self.get_dependencies(instance.data["setMembers"][0], dependencies)
-
-        # Get backdrops.
-        backdrops = {}
-        for dependency in dependencies:
-            for backdrop in self.get_backdrops(dependency):
-                backdrops[backdrop["title"]["text"]] = backdrop
-        unique_backdrops = [backdrops[x] for x in set(backdrops.keys())]
-        if not unique_backdrops:
-            self.log.error(("No backdrops detected for template. "
-                            "Please move template instance node onto "
-                            "some backdrop and try again."))
-            raise AssertionError("No backdrop detected")
-        # Get non-connected nodes within backdrops.
-        all_nodes = instance.context.data.get("allNodes")
-        for node in [x for x in all_nodes if x not in dependencies]:
-            within_unique_backdrops = bool(
-                [x for x in self.get_backdrops(node) if x in unique_backdrops]
-            )
-            if within_unique_backdrops:
-                dependencies.append(node)
-
-        # Make sure we dont export the instance node.
-        if instance.data["setMembers"][0] in dependencies:
-            dependencies.remove(instance.data["setMembers"][0])
-
-        # Export template.
-        harmony.export_template(
-            unique_backdrops, dependencies, filepath
+        # Export template
+        harmony.export_backdrop_as_template(
+            instance.data["setMembers"][0], filepath
         )
 
         # Prep representation.
@@ -58,7 +31,7 @@ class ExtractTemplate(publish.Extractor):
         shutil.make_archive(
             f"{instance.name}",
             "zip",
-            staging_dir,
+            os.path.join(staging_dir, "harmony"),
         )
 
         representation = {
@@ -78,49 +51,3 @@ class ExtractTemplate(publish.Extractor):
             instance.data["productName"],
             instance.context.data["task"]
         )
-
-    def get_backdrops(self, node: str) -> list:
-        """Get backdrops for the node.
-
-        Args:
-            node (str): Node path.
-
-        Returns:
-            list: list of Backdrops.
-
-        """
-        self_name = self.__class__.__name__
-        return harmony.send({
-            "function": f"AyonHarmony.Publish.{self_name}.getBackdropsByNode",
-            "args": node})["result"]
-
-    def get_dependencies(
-            self, node: str, dependencies: list = None) -> list:
-        """Get node dependencies.
-
-        This will return recursive dependency list of given node.
-
-        Args:
-            node (str): Path to the node.
-            dependencies (list, optional): existing dependency list.
-
-        Returns:
-            list: List of dependent nodes.
-
-        """
-        current_dependencies = harmony.send(
-            {
-                "function": "AyonHarmony.getDependencies",
-                "args": node}
-        )["result"]
-
-        for dependency in current_dependencies:
-            if not dependency:
-                continue
-
-            if dependency in dependencies:
-                continue
-
-            dependencies.append(dependency)
-
-            self.get_dependencies(dependency, dependencies)


### PR DESCRIPTION
## Changelog Description
Refactor (and fix) of the template workflow to rely on backdrops instead of composite node.

## Additional review information
**NB: Still in WIP, the PR is made to have feedback on the main design and adjust it if necessary. Also added some `TODO` which can be discussed.**

Advantages of relying on backdrops instead of nodes:
- More flexibility over what is possible to publish (a library of unconnected nodes for example).
- More explicit comprehension of what's going to be published, it is actually a container of nodes.
- Implies a clean organization of nodes in scene.
- Code is more straightforward and lightweight.
- It seems that's what was intended in the first place because the composite container node was supposed to be into a backdrop but the lack of backdrop API in OpenHarmony forced to rely on nodes.

## Testing notes:
1. In a new harmony workfile, `AYON > Create` a `Template`.
2. Put some nodes into the created backdrop.
3. Publish
4. In a new harmony workfile, `AYON > Load` the published template. (not `Import`)
5. Here is your backdrop with its contents.

## TODOs before it's fully ready
- [x] Export sub-backdrops included in the container backdrop
- [x] Update/switch loaded container
- [x] Remove loaded container
- [x] Use a selected backdrop to convert it as the container backdrop

There are others things that can be added to make the whole thing more handy (some might be signaled as `TODO` directly in code comments, but they aren't mandatory IMO)