### PR TITLE
Feature: cleanup orphaned containers

### DIFF
--- a/client/ayon_harmony/api/__init__.py
+++ b/client/ayon_harmony/api/__init__.py
@@ -32,6 +32,7 @@ from .lib import (
     select_nodes,
     get_scene_data,
     set_scene_data,
+    get_all_top_names,
 )
 
 from .workio import (
@@ -72,6 +73,7 @@ __all__ = [
     "select_nodes",
     "get_scene_data",
     "set_scene_data",
+    "get_all_top_names",
 
     # Workfiles API
     "open_file",

--- a/client/ayon_harmony/api/lib.py
+++ b/client/ayon_harmony/api/lib.py
@@ -481,6 +481,19 @@ def delete_node(node):
         }
     )
 
+def get_all_top_names() -> set:
+    """Get all top node and backdrop names in the scene.
+
+    Returns:
+        set: Set of top node names.
+    """
+    return set(send({"function": "node.subNodes", "args": ["Top"]})["result"]) | {
+        backdrop["title"]["text"]
+        for backdrop in send({"function": "Backdrop.backdrops", "args": ["Top"]})[
+            "result"
+        ]
+    }
+
 
 def imprint(node_id, data, remove=False):
     """Write `data` to the `node` as json.

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -246,17 +246,31 @@ def is_container_data(data: dict) -> bool:
 def ls():
     """Yields containers from Harmony scene.
 
+    Clean up scene data from orphaned containers.
+
     Yields:
         dict: container
     """
-    objects = harmony.get_scene_data() or {}
-    for _, data in objects.items():
-        if not is_container_data(data):
+    scene_data = harmony.get_scene_data() or dict()
+    all_top_names = harmony.get_all_top_names()
+    cleaned_scene_data = True
+    for entity_name, entity_data in scene_data.copy().items():
+        if not is_container_data(entity_data):
             continue
 
-        if not data.get("objectName"):  # backward compatibility
-            data["objectName"] = data["name"]
-        yield data
+        # Filter orphaned containers
+        if entity_name not in all_top_names:
+            del scene_data[entity_name]
+            cleaned_scene_data = True
+            continue
+
+        if not entity_data.get("objectName"):  # backward compatibility
+            entity_data["objectName"] = entity_data["name"]
+        yield entity_data
+
+    # Update scene data if cleaned
+    if cleaned_scene_data:
+        harmony.set_scene_data(scene_data)
 
 
 def containerise(name,

--- a/client/ayon_harmony/api/plugin.py
+++ b/client/ayon_harmony/api/plugin.py
@@ -29,19 +29,9 @@ class HarmonyCreatorBase:
             cache = dict()
             cache_legacy = dict()
 
-            node_names = harmony.send(
-                {"function": "node.subNodes", "args": ["Top"]}
-            )["result"]
-            backdrops = harmony.send(
-                {"function": "Backdrop.backdrops", "args": ["Top"]}
-            )["result"]
-            backdrop_names = [
-                backdrop["title"]["text"]
-                for backdrop in backdrops
-            ]
-            all_top_names = set(node_names) | set(backdrop_names)
             # Collect scene data once instead of calling `read()` per node
             scene_data = harmony.get_scene_data()
+            all_top_names = harmony.get_all_top_names()
             cleaned_scene_data = False
             for entity_name, entity_data in reversed(scene_data.copy().items()):
                 # Filter orphaned instances


### PR DESCRIPTION
## Changelog Description
Container entities in node view (Backdrop or node) removed by hand are cleaned up from the metadata at manage refreshing.

## Additional review information
Based on code introduced in https://github.com/ynput/ayon-harmony/pull/34.
The current PR is proposed to https://github.com/ynput/ayon-harmony/pull/17 because of code history, but I'm not sure it belongs to it, it should be merged on `develop` after the base PR is merged IMO. Up to you to decide.

## Testing notes:
1. Load a template container
2. Open Manage
3. Delete the backdrop directly in Node View
4. Refresh Manage 
