### PR TITLE
Fix: Load published tpl regardless of the instance name

### DIFF
--- a/client/ayon_harmony/plugins/load/load_template.py
+++ b/client/ayon_harmony/plugins/load/load_template.py
@@ -3,7 +3,6 @@
 from pathlib import Path
 import tempfile
 import zipfile
-import os
 import shutil
 
 from ayon_core.pipeline import (

--- a/client/ayon_harmony/plugins/load/load_template.py
+++ b/client/ayon_harmony/plugins/load/load_template.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Load template."""
+from pathlib import Path
 import tempfile
 import zipfile
 import os
@@ -34,14 +35,15 @@ class TemplateLoader(load.LoaderPlugin):
         self_name = self.__class__.__name__
         temp_dir = tempfile.mkdtemp()
         zip_file = get_representation_path(context["representation"])
-        template_path = os.path.join(temp_dir)
+
         with zipfile.ZipFile(zip_file, "r") as zip_ref:
-            zip_ref.extractall(template_path)
+            zip_ref.extractall(temp_dir)
 
         backdrop_name = harmony.send(
             {
                 "function": f"AyonHarmony.Loaders.{self_name}.loadContainer",
-                "args": os.path.join(template_path, "harmony.tpl")
+                # Published tpl name is not consistent, use first found, must be only one
+                "args": next(Path(temp_dir).glob("*.tpl")).as_posix(),
             }
         )["result"]
 


### PR DESCRIPTION
## Changelog Description
Use first occurrence of `.tpl` in the published archive instead of relying on an arbitrary name.

## Additional review information
The published `.tpl` name might change if you change the naming templates, in this case, all previously published `tpl` will become unloadable. This change makes the template file finding more versatile.

## Testing notes:
1. Change the template naming for `harmony.template` to something like `{variant}` only (or anything which doesn't start with` `{product[type]}`). NB: You can't use any key because of https://github.com/ynput/ayon-core/issues/1213
2. Load a previously published template
3. Publish a new template
4. Load it into a scene
