### PR TITLE
Fix: Template instance creation wrong backdrop used

### DIFF
--- a/client/ayon_harmony/api/js/AyonHarmonyAPI.js
+++ b/client/ayon_harmony/api/js/AyonHarmonyAPI.js
@@ -264,45 +264,6 @@ AyonHarmonyAPI.createNodeContainer = function(args) {
 
 
 /**
- * Create container backdrop in Harmony.
- * @function
- * @param {array} args Arguments, see example.
- * @return {string} Resulting backdrop.
- *
- * @example
- * // arguments are in following order:
- * var args = [
- *  backdropName,
- *  useSelection
- * ];
- */
-AyonHarmonyAPI.createBackdropContainer = function(args) {
-    var backdropName = args[0];
-    var useSelection = args[1];
-    var selectedBackdrops = selection.selectedBackdrops();
-
-    if (useSelection && selectedBackdrops.length > 0) {
-        // Rename selected backdrop
-        var allBackdrops = Backdrop.backdrops("Top");
-        var selectedBackdropIdx = allBackdrops.map(function(b) { return b.title.text; }).indexOf(selectedBackdrops[0].title.text);
-        allBackdrops[selectedBackdropIdx].title.text = backdropName;
-        Backdrop.setBackdrops("Top", allBackdrops);
-        return allBackdrops[selectedBackdropIdx];
-    } else {
-        // Create new backdrop
-        return Backdrop.addBackdrop(
-            "Top",
-            {
-                "position"    : {"x": 0, "y" :0, "w":300, "h":300},
-                "title"       : {"text" : backdropName, "size" : 14, "font" : "Arial"},
-                // "color"       : TODO
-            }
-        );
-    }
-};
-
-
-/**
  * Delete node.
  * @function
  * @param {string} node Node path.

--- a/client/ayon_harmony/js/AyonHarmony.js
+++ b/client/ayon_harmony/js/AyonHarmony.js
@@ -221,6 +221,69 @@ AyonHarmony.getBackdropLinks = function(backdrop) {
     return nodesLinks;
 };
 
+
+/**
+ * Create container backdrop in Harmony.
+ * @function
+ * @param {array} args Arguments, see example.
+ * @return {string} Resulting backdrop.
+ *
+ * @example
+ * // arguments are in following order:
+ * var args = [
+ *  backdropName,
+ *  useSelection
+ * ];
+ */
+AyonHarmony.createBackdropContainer = function(args) {
+    var backdropName = args[0];
+    var useSelection = args[1];
+    var selectedBackdrops = selection.selectedBackdrops();
+
+    if (useSelection && selectedBackdrops.length > 0) {
+        // Rename root backdrop of selection
+        // Sh*tty harmony API forces to rewrite all backdrops
+        var rootBackdrop = AyonHarmony.getRootBackdrop(selectedBackdrops);
+        var allBackdrops = Backdrop.backdrops("Top");
+        var selectedBackdropIdx = allBackdrops.map(function(b) { return b.title.text; }).indexOf(rootBackdrop.title.text);
+        allBackdrops[selectedBackdropIdx].title.text = backdropName;
+        Backdrop.setBackdrops("Top", allBackdrops);
+        return allBackdrops[selectedBackdropIdx];
+    } else {
+        // Create new backdrop
+        return Backdrop.addBackdrop(
+            "Top",
+            {
+                "position"    : {"x": 0, "y" :0, "w":300, "h":300},
+                "title"       : {"text" : backdropName, "size" : 14, "font" : "Arial"},
+                // "color"       : TODO
+            }
+        );
+    }
+};
+
+
+/**
+ * Get root backdrop.
+ * The root backdrop is the backdrop that contains all other backdrops.
+ * @function
+ * @param {array} backdrops List of backdrops.
+ * @return {object} Root backdrop.
+ */
+AyonHarmony.getRootBackdrop = function(backdrops) {
+    // Sort backdrops by x, y position and width, height
+    backdrops.sort(function(a, b) {
+        if (a.position.x != b.position.x) return a.position.x - b.position.x;
+        if (a.position.y != b.position.y) return a.position.y - b.position.y;
+        if (a.position.w != b.position.w) return a.position.w - b.position.w;
+        if (a.position.h != b.position.h) return a.position.h - b.position.h;
+        return 0;
+    });
+
+    return backdrops[0];
+}
+
+
 /**
  * Set nodes links.
  * @function

--- a/client/ayon_harmony/plugins/create/create_template.py
+++ b/client/ayon_harmony/plugins/create/create_template.py
@@ -18,7 +18,7 @@ class CreateTemplate(plugin.HarmonyCreator):
         args = [name, pre_create_data.get("use_selection") ]
         backdrop = harmony.send(
             {
-                "function": "AyonHarmonyAPI.createBackdropContainer",
+                "function": "AyonHarmony.createBackdropContainer",
                 "args": args
             }
         )["result"]


### PR DESCRIPTION
## Changelog Description
When creating a backdrop from selection, the root backdrop (the one containing all others) will be found and used.

## Additional review information
Harmony stores the backdrops list by creation order, when you select a backdrop which contains all others (the root one), if it has been inserted in scene last or before any of the ones it contains, it wont be used for creation, but the last inserted one will. 

NB: I moved `createBackdropContainer` from `AyonHarmonyAPI.js` to `AyonHarmony` to keep backdrop related functions together and wrote a `getRootBackdrop`. This duplication of `.js` files with very similar names is pretty confusing, it should be cleaned IMO.

## Testing notes:
1. Select an existing backdrop
2. In node view menu insert a new backdrop
3. Unselect by clicking out of any backdrop
4. Select this new backdrop by clicking on it (it'll select it with all its content)
5. In `Create` create a new template instance from selection
