### PR TITLE
Clean: Delete deprecated load template functions

### DIFF
--- a/client/ayon_harmony/plugins/load/load_template.py
+++ b/client/ayon_harmony/plugins/load/load_template.py
@@ -105,19 +105,3 @@ class TemplateLoader(load.LoaderPlugin):
         )
 
         return container
-
-    def _set_green(self, node): # TODO refactor for backdrop
-        """Set node color to green `rgba(0, 255, 0, 255)`."""
-        harmony.send(
-            {
-                "function": "AyonHarmony.setColor",
-                "args": [node, [0, 255, 0, 255]]
-            })
-
-    def _set_red(self, node): # TODO refactor for backdrop
-        """Set node color to red `rgba(255, 0, 0, 255)`."""
-        harmony.send(
-            {
-                "function": "AyonHarmony.setColor",
-                "args": [node, [255, 0, 0, 255]]
-            })


### PR DESCRIPTION
## Changelog Description
Deleted `_set_green` and `_set_red` functions from `TemplateLoader` because unused and deprecated.

## Additional review information
Since #31 has been merged, the backdrop behaviour changed and there are no color change any more, for the best.

## Testing notes:
1. Update a loaded template
