### PR TITLE
Fix: Linked palettes are collected and published

### DIFF
--- a/client/ayon_harmony/js/publish/CollectPalettes.js
+++ b/client/ayon_harmony/js/publish/CollectPalettes.js
@@ -13,16 +13,30 @@ if (typeof AyonHarmony === 'undefined') {
 
 /**
  * @namespace
- * @classdesc Image Sequence loader JS code.
+ * @classdesc CollectPalettes JS code.
  */
 var CollectPalettes = function() {};
 
-CollectPalettes.prototype.getPalettes = function() {
+/**
+ * Get palettes from Harmony.
+ * @function
+ * @param {boolean} [local_only=false] If true, only local palettes will be returned.
+ * @return {object} Object with palette names and ids.
+ */
+CollectPalettes.prototype.getPalettes = function(local_only) {
+    if (typeof local_only === 'undefined') var local_only = false;
+
     var palette_list = PaletteObjectManager.getScenePaletteList();
 
     var palettes = {};
     for(var i=0; i < palette_list.numPalettes; ++i) {
         var palette = palette_list.getPaletteByIndex(i);
+        
+        // if local_only is true, skip external palettes
+        if (local_only && palette.location == PaletteObjectManager.Constants.Location.EXTERNAL) {
+            continue;
+        }
+        
         palettes[palette.getName()] = palette.id;
     }
 

--- a/client/ayon_harmony/plugins/publish/collect_palettes.py
+++ b/client/ayon_harmony/plugins/publish/collect_palettes.py
@@ -25,6 +25,7 @@ class CollectPalettes(pyblish.api.ContextPlugin):
         palettes = harmony.send(
             {
                 "function": f"AyonHarmony.Publish.{self_name}.getPalettes",
+                "args": True,
             })["result"]
 
         # skip collecting if not in allowed task


### PR DESCRIPTION
## Changelog Description
Added `local_only` argument to `getPalettes` in order to skip linked (external) palettes from being collected.

## Additional review information
Linked palettes are not meant to be published because they are not supposed to be altered within the current scene. Publishing them is confusing.

## Testing notes:
1. Link a published palette (see #40)
2. Create a new local one
3. Run tests from publish and see that only local ones are collected
