### PR TITLE
Fix: Extract Render single image

### DIFF
--- a/client/ayon_harmony/plugins/publish/extract_render.py
+++ b/client/ayon_harmony/plugins/publish/extract_render.py
@@ -119,11 +119,10 @@ class ExtractRender(pyblish.api.InstancePlugin):
         # Generate representations.
         extension = collection.tail[1:]
         files = list(collection)
-        is_image_sequence = len(files) > 1
         representation = {
             "name": extension,
             "ext": extension,
-            "files": files if is_image_sequence else files[0],
+            "files": files if len(files) > 1 else files[0],
             "stagingDir": path,
             "tags": ["review"],
             "fps": frame_rate
@@ -131,15 +130,15 @@ class ExtractRender(pyblish.api.InstancePlugin):
         representations = [representation]
 
         # Add thumbnail if it's an image sequence
-        if is_image_sequence:
-            thumbnail = {
-                "name": "thumbnail",
-                "ext": "png",
-                "files": os.path.basename(thumbnail_path),
-                "stagingDir": path,
-                "tags": ["thumbnail"]
-            }
-            representations.append(thumbnail)
+        thumbnail = {
+            "name": "thumbnail",
+            "ext": "png",
+            "files": os.path.basename(thumbnail_path),
+            "stagingDir": path,
+            "tags": ["thumbnail"],
+            "outputName": "thumbnail"
+        }
+        representations.append(thumbnail)
         
         instance.data["representations"] = representations
 

--- a/client/ayon_harmony/plugins/publish/extract_render.py
+++ b/client/ayon_harmony/plugins/publish/extract_render.py
@@ -21,7 +21,6 @@ class ExtractRender(pyblish.api.InstancePlugin):
 
     def process(self, instance):
         # Collect scene data.
-        self.log.info("updat")
         application_path = instance.context.data.get("applicationPath")
         scene_path = instance.context.data.get("scenePath")
         frame_rate = instance.context.data.get("frameRate")

--- a/client/ayon_harmony/plugins/publish/extract_render.py
+++ b/client/ayon_harmony/plugins/publish/extract_render.py
@@ -15,7 +15,7 @@ class ExtractRender(pyblish.api.InstancePlugin):
     """
 
     label = "Extract Render"
-    order = order = pyblish.api.ExtractorOrder - 0.0001 # TODO remove decrement after ayon-core ExtractThumbnailFromSource is set later
+    order = pyblish.api.ExtractorOrder - 0.0001 # TODO remove decrement after ayon-core ExtractThumbnailFromSource is set later
     hosts = ["harmony"]
     families = ["render.local"]
 

--- a/client/ayon_harmony/plugins/publish/extract_render.py
+++ b/client/ayon_harmony/plugins/publish/extract_render.py
@@ -15,13 +15,13 @@ class ExtractRender(pyblish.api.InstancePlugin):
     """
 
     label = "Extract Render"
-    order = pyblish.api.ExtractorOrder
+    order = order = pyblish.api.ExtractorOrder - 0.0001 # TODO remove decrement after ayon-core ExtractThumbnailFromSource is set later
     hosts = ["harmony"]
     families = ["render.local"]
 
     def process(self, instance):
         # Collect scene data.
-
+        self.log.info("updat")
         application_path = instance.context.data.get("applicationPath")
         scene_path = instance.context.data.get("scenePath")
         frame_rate = instance.context.data.get("frameRate")
@@ -92,29 +92,8 @@ class ExtractRender(pyblish.api.InstancePlugin):
         else:
             collection = collections[0]
 
-        # Generate thumbnail.
-        thumbnail_path = os.path.join(path, "thumbnail.png")
-        args = ayon_core.lib.get_ffmpeg_tool_args(
-            "ffmpeg",
-            "-y",
-            "-i", os.path.join(path, list(collections[0])[0]),
-            "-vf", "scale=300:-1",
-            "-vframes", "1",
-            thumbnail_path
-        )
-        process = subprocess.Popen(
-            args,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            stdin=subprocess.PIPE
-        )
-
-        output = process.communicate()[0]
-
-        if process.returncode != 0:
-            raise ValueError(output.decode("utf-8", errors="backslashreplace"))
-
-        self.log.debug(output.decode("utf-8", errors="backslashreplace"))
+        thumbnail_source = os.path.join(path, list(collections[0])[0])
+        instance.data["thumbnailSource"] = thumbnail_source
 
         # Generate representations.
         extension = collection.tail[1:]
@@ -128,17 +107,6 @@ class ExtractRender(pyblish.api.InstancePlugin):
             "fps": frame_rate
         }
         representations = [representation]
-
-        # Add thumbnail if it's an image sequence
-        thumbnail = {
-            "name": "thumbnail",
-            "ext": "png",
-            "files": os.path.basename(thumbnail_path),
-            "stagingDir": path,
-            "tags": ["thumbnail"],
-            "outputName": "thumbnail"
-        }
-        representations.append(thumbnail)
         
         instance.data["representations"] = representations
 

--- a/client/ayon_harmony/plugins/publish/extract_render.py
+++ b/client/ayon_harmony/plugins/publish/extract_render.py
@@ -118,23 +118,30 @@ class ExtractRender(pyblish.api.InstancePlugin):
 
         # Generate representations.
         extension = collection.tail[1:]
+        files = list(collection)
+        is_image_sequence = len(files) > 1
         representation = {
             "name": extension,
             "ext": extension,
-            "files": list(collection),
+            "files": files if is_image_sequence else files[0],
             "stagingDir": path,
             "tags": ["review"],
             "fps": frame_rate
         }
+        representations = [representation]
 
-        thumbnail = {
-            "name": "thumbnail",
-            "ext": "png",
-            "files": os.path.basename(thumbnail_path),
-            "stagingDir": path,
-            "tags": ["thumbnail"]
-        }
-        instance.data["representations"] = [representation, thumbnail]
+        # Add thumbnail if it's an image sequence
+        if is_image_sequence:
+            thumbnail = {
+                "name": "thumbnail",
+                "ext": "png",
+                "files": os.path.basename(thumbnail_path),
+                "stagingDir": path,
+                "tags": ["thumbnail"]
+            }
+            representations.append(thumbnail)
+        
+        instance.data["representations"] = representations
 
         if audio_path and os.path.exists(audio_path):
             instance.data["audio"] = [{"filename": audio_path}]


### PR DESCRIPTION
## Changelog Description
`ExtractRender` set `files` attribute of representation to the path of the single file when only one frame has been rendered. Skip thumbnail representation in this case.

## Additional review information
From issue on `ayon-core` https://github.com/ynput/ayon-core/issues/1274

## Testing notes:
1. Open harmony scene for an asset with only 1 frame
2. Create a render instance
3. Publish, it passes accordingly

