### PR TITLE
Fix: Validate instance settings

### DIFF
--- a/client/ayon_harmony/plugins/publish/validate_instances.py
+++ b/client/ayon_harmony/plugins/publish/validate_instances.py
@@ -1,7 +1,7 @@
 import pyblish.api
 
 import ayon_harmony.api as harmony
-from ayon_core.pipeline import get_current_folder_path
+from ayon_core.pipeline import get_current_folder_path, OptionalPyblishPluginMixin
 from ayon_core.pipeline.publish import (
     ValidateContentsOrder,
     PublishXmlValidationError,
@@ -34,7 +34,7 @@ class ValidateInstanceRepair(pyblish.api.Action):
             harmony.imprint(instance.data["setMembers"][0], data)
 
 
-class ValidateInstance(pyblish.api.InstancePlugin):
+class ValidateInstance(pyblish.api.InstancePlugin, OptionalPyblishPluginMixin):
     """Validate the instance folder is the current folder."""
 
     label = "Validate Instance"
@@ -44,6 +44,9 @@ class ValidateInstance(pyblish.api.InstancePlugin):
     optional = True
 
     def process(self, instance):
+        if not self.is_active(instance.data):
+            return
+
         instance_folder_path = instance.data["folderPath"]
         current_colder_path = get_current_folder_path()
         msg = (

--- a/client/ayon_harmony/plugins/publish/validate_instances.py
+++ b/client/ayon_harmony/plugins/publish/validate_instances.py
@@ -48,17 +48,17 @@ class ValidateInstance(pyblish.api.InstancePlugin, OptionalPyblishPluginMixin):
             return
 
         instance_folder_path = instance.data["folderPath"]
-        current_colder_path = get_current_folder_path()
+        current_folder_path = get_current_folder_path()
         msg = (
             "Instance folder is not the same as current folder:"
             f"\nInstance: {instance_folder_path}]"
-            f"\nCurrent: {current_colder_path}"
+            f"\nCurrent: {current_folder_path}"
         )
 
         formatting_data = {
             "found": instance_folder_path,
-            "expected": current_colder_path
+            "expected": current_folder_path
         }
-        if instance_folder_path != current_colder_path:
+        if instance_folder_path != current_folder_path:
             raise PublishXmlValidationError(self, msg,
                                             formatting_data=formatting_data)

--- a/client/ayon_harmony/plugins/publish/validate_instances.py
+++ b/client/ayon_harmony/plugins/publish/validate_instances.py
@@ -41,6 +41,7 @@ class ValidateInstance(pyblish.api.InstancePlugin):
     hosts = ["harmony"]
     actions = [ValidateInstanceRepair]
     order = ValidateContentsOrder
+    optional = True
 
     def process(self, instance):
         instance_folder_path = instance.data["folderPath"]

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -59,6 +59,11 @@ DEFAULT_HARMONY_SETTING = {
             "frame_check_filter": [],
             "skip_resolution_check": [],
             "skip_timelines_check": []
+        },
+        "ValidateInstances": {
+            "enabled": True,
+            "optional": True,
+            "active": True
         }
     }
 }

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -14,7 +14,7 @@ class ValidateAudioPlugin(BaseSettingsModel):
     """Check if scene contains audio track."""  #
     _isGroup = True
     enabled: bool = True
-    optional: bool = SettingsField(False, title="Optional")
+    optional: bool = SettingsField(True, title="Optional")
     active: bool = SettingsField(True, title="Active")
 
 

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -43,6 +43,13 @@ class ValidateSceneSettingsPlugin(BaseSettingsModel):
     )
 
 
+class ValidateInstancePlugin(BaseSettingsModel):
+    """Validate if instance folder is the current folder."""
+    enabled: bool = True
+    optional: bool = SettingsField(False, title="Optional")
+    active: bool = SettingsField(True, title="Active")
+
+
 class HarmonyPublishPlugins(BaseSettingsModel):
 
     CollectPalettes: CollectPalettesPlugin = SettingsField(
@@ -58,4 +65,9 @@ class HarmonyPublishPlugins(BaseSettingsModel):
     ValidateSceneSettings: ValidateSceneSettingsPlugin = SettingsField(
         title="Validate Scene Settings",
         default_factory=ValidateSceneSettingsPlugin,
+    )
+
+    ValidateInstance: ValidateInstancePlugin = SettingsField(
+        title="Validate Instance",
+        default_factory=ValidateInstancePlugin,
     )


### PR DESCRIPTION
## Changelog Description
Added server settings for `ValidateInstance` and `optional` attribute.

## Additional review information
This plugin being mandatory blocks the possibility of creating instance for another asset than the one with current file we are working in.

## Testing notes:
1. Create a template instance from another asset you open the workfile of
2. Disable `ValidateInstance`
3. Publish
