### PR TITLE
Use launcher settings for opening workfile on launch

### DIFF
--- a/client/ayon_harmony/api/lib.py
+++ b/client/ayon_harmony/api/lib.py
@@ -20,7 +20,7 @@ import collections
 
 from qtpy import QtWidgets, QtCore, QtGui
 
-from ayon_core.lib import is_using_ayon_console
+from ayon_core.lib import is_using_ayon_console, env_value_to_bool
 from ayon_core.tools.stdout_broker import StdOutBroker
 from ayon_core.tools.utils import host_tools
 from ayon_core import style
@@ -199,17 +199,24 @@ def launch(application_path, *args):
     setup_startup_scripts()
     check_libs()
 
-    if not os.environ.get("AYON_HARMONY_WORKFILES_ON_LAUNCH", False):
+    # If no workfile is provided, open an empty workfile.
+    if len(args) == 0:
         open_empty_workfile()
         return
 
     if len(args) > 0 and (scene_path := Path(args[-1])).suffix == ".xstage":
         launch_zip_file(scene_path)
         return
-    
-    ProcessContext.workfile_tool = host_tools.get_tool_by_name("workfiles")
-    host_tools.show_workfiles(save=False)
-    ProcessContext.execute_in_main_thread(check_workfiles_tool)
+
+    # Whether to show workfiles on launch.
+    env_workfiles_on_launch = os.getenv( "AYON_AFTEREFFECTS_WORKFILES_ON_LAUNCH",
+        # Backwards compatibility
+        os.getenv("AVALON_AFTEREFFECTS_WORKFILES_ON_LAUNCH", True)
+    )
+    if env_value_to_bool(value=env_workfiles_on_launch):
+        ProcessContext.workfile_tool = host_tools.get_tool_by_name("workfiles")
+        host_tools.show_workfiles(save=False)
+        ProcessContext.execute_in_main_thread(check_workfiles_tool)
 
 
 def check_workfiles_tool():

--- a/client/ayon_harmony/hooks/pre_launch_args.py
+++ b/client/ayon_harmony/hooks/pre_launch_args.py
@@ -77,6 +77,10 @@ class HarmonyPrelaunchHook(PreLaunchHook):
             and os.path.exists(workfile_path)
         ):
             new_launch_args.append(unzip_scene_file(workfile_path))
+        
+        workfile_startup = self.data.get("workfile_startup", False)
+        # set the env variable AYON_AFTEREFFECTS_WORKFILES_ON_LAUNCH to "true" or "false"
+        self.launch_context.env["AYON_AFTEREFFECTS_WORKFILES_ON_LAUNCH"] = str(workfile_startup).lower()
 
         # Append as whole list as these arguments should not be separated
         self.launch_context.launch_args.append(new_launch_args)


### PR DESCRIPTION
## Changelog Description
Similar implementation to this PR: https://github.com/ynput/ayon-aftereffects/pull/39 

## Additional review information
Use self.data.get("workfile_startup", False) to determine if the workfile tool should be opened on startup

## Testing notes:
1. start with this step
use ayon+settings://core/tools/Workfiles/open_workfile_tool_on_startup to setup whether to open workfile tool should be opened or not
2.1 start the harmony on a task without any workfile
2.2 start the harmony on a task with workfile
