### PR TITLE
Feature: env var to add custom list of js scripts for Harmony

### DIFF
--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -239,7 +239,8 @@ def inject_ayon_js():
 
     # send additional scripts to Harmony
     for script in os.getenv("AYON_HARMONY_ADDITIONAL_SCRIPTS").split(";"):
-        harmony.send({"script": Path(script).read_text()})
+        if script:
+            harmony.send({"script": Path(script).read_text()})
 
 
 def is_container_data(data: dict) -> bool:

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -237,6 +237,10 @@ def inject_ayon_js():
     # send AyonHarmonyAPI.js to Harmony
     harmony.send({"script": script})
 
+    # send additional scripts to Harmony
+    for script in os.getenv("AYON_HARMONY_ADDITIONAL_SCRIPTS").split(";"):
+        harmony.send({"script": Path(script).read_text()})
+
 
 def is_container_data(data: dict) -> bool:
     """Return whether data is container data."""

--- a/client/ayon_harmony/hooks/pre_launch_args.py
+++ b/client/ayon_harmony/hooks/pre_launch_args.py
@@ -90,5 +90,5 @@ class HarmonyPrelaunchHook(PreLaunchHook):
 
         # Add additional scripts to the environment
         self.launch_context.kwargs["env"].setdefault(
-            "AYON_HARMONY_ADDITIONAL_SCRIPTS", []
+            "AYON_HARMONY_ADDITIONAL_SCRIPTS", ""
         )

--- a/client/ayon_harmony/hooks/pre_launch_args.py
+++ b/client/ayon_harmony/hooks/pre_launch_args.py
@@ -87,3 +87,8 @@ class HarmonyPrelaunchHook(PreLaunchHook):
         self.launch_context.kwargs = get_launch_kwargs(
             self.launch_context.kwargs
         )
+
+        # Add additional scripts to the environment
+        self.launch_context.kwargs["env"].setdefault(
+            "AYON_HARMONY_ADDITIONAL_SCRIPTS", []
+        )


### PR DESCRIPTION
## Changelog Description
Use `AYON_HARMONY_ADDITIONAL_SCRIPTS` env var in prelaunch hooks to pass a list of JS scripts separated by `;` to be sent to Harmony at startup.

## Additional review information


## Testing notes:
1. Copy these two files into `ayon-harmony/client/ayon_harmony/hooks` 
[test_ui.js](https://github.com/user-attachments/files/22138292/test_ui.js)
[pre_harmony_launch_test.py](https://github.com/user-attachments/files/22138293/pre_harmony_launch_test.py)
2. Start Harmony
3. `TEST` menu tab is added in the top bar
