### PR TITLE
Chore: Drive opening of Workfiles after startup by Core

### DIFF
--- a/client/ayon_harmony/hooks/pre_launch_args.py
+++ b/client/ayon_harmony/hooks/pre_launch_args.py
@@ -79,7 +79,9 @@ class HarmonyPrelaunchHook(PreLaunchHook):
         
         workfile_startup = self.data.get("workfile_startup", True)
 
-        self.launch_context.env["AYON_HARMONY_WORKFILES_ON_LAUNCH"] = str(workfile_startup).lower()
+        self.launch_context.env["AYON_HARMONY_WORKFILES_ON_LAUNCH"] = str(
+            int(workfile_startup)
+        )
 
         # Append as whole list as these arguments should not be separated
         self.launch_context.launch_args.append(new_launch_args)

--- a/client/ayon_harmony/hooks/pre_launch_args.py
+++ b/client/ayon_harmony/hooks/pre_launch_args.py
@@ -78,8 +78,7 @@ class HarmonyPrelaunchHook(PreLaunchHook):
             new_launch_args.append(workfile_path)
         
         workfile_startup = self.data.get("workfile_startup", True)
-        
-        # set the env variable AYON_AFTEREFFECTS_WORKFILES_ON_LAUNCH to "true" or "false"
+
         self.launch_context.env["AYON_HARMONY_WORKFILES_ON_LAUNCH"] = str(workfile_startup).lower()
 
         # Append as whole list as these arguments should not be separated

--- a/client/ayon_harmony/hooks/pre_launch_args.py
+++ b/client/ayon_harmony/hooks/pre_launch_args.py
@@ -76,6 +76,11 @@ class HarmonyPrelaunchHook(PreLaunchHook):
             and os.path.exists(workfile_path)
         ):
             new_launch_args.append(workfile_path)
+        
+        workfile_startup = self.data.get("workfile_startup", True)
+        
+        # set the env variable AYON_AFTEREFFECTS_WORKFILES_ON_LAUNCH to "true" or "false"
+        self.launch_context.env["AYON_HARMONY_WORKFILES_ON_LAUNCH"] = str(workfile_startup).lower()
 
         # Append as whole list as these arguments should not be separated
         self.launch_context.launch_args.append(new_launch_args)


### PR DESCRIPTION
## Changelog Description
Opening of `Workfiles` app was previously controlled by environment variable in `Applications`. Standard way is to use profiles in `Core` addon which provide more granular control.

## Additional review information
`Applications` should be eventually cleaned up too.

## Testing notes:
1. experiment with `ayon+settings://core/tools/Workfiles/open_workfile_tool_on_startup`
2. if task doesn't contain any workfiles, it will always open Workfiles to allow to Browse workfile outside of task folder. If Workfiles app is closed, it will deploy dummy vendorized workfile.
