### PR TITLE
Feature: Workfiles copy and open

### DIFF
--- a/client/ayon_harmony/api/lib.py
+++ b/client/ayon_harmony/api/lib.py
@@ -207,7 +207,7 @@ def launch(application_path, *args):
     workfile_already_open = ProcessContext.workfile_path
     if open_workfile_app or not workfile_already_open:
         ProcessContext.workfile_tool = host_tools.get_tool_by_name("workfiles")
-        host_tools.show_workfiles(save=False)
+        host_tools.show_workfiles(save=True)
         ProcessContext.execute_in_main_thread(check_workfiles_tool)
 
 


### PR DESCRIPTION
## Changelog Description
Enable `Copy and Open` button for Workfiles window at launch.

## Additional review information
This is a proposal for solving https://github.com/ynput/ayon-core/issues/1448
It works out of the box actually.

## Testing notes:
1. Launch a task from a folder which have a published workfile
2. On Workfiles window, go to `Published` and click on `Copy and Open`
