### PR TITLE
Feature: Instance active state stored to nodes only for render

### DIFF
--- a/client/ayon_harmony/api/plugin.py
+++ b/client/ayon_harmony/api/plugin.py
@@ -144,7 +144,7 @@ class HarmonyCreator(Creator, HarmonyCreatorBase):
 
     def get_active_state(self, instance: CreatedInstance):
         """Get active state of the instance.
-        
+
         Args:
             instance (CreatedInstance): Instance.
 


### PR DESCRIPTION
## Changelog Description
Instance state is stored to nodes only for render instances.

## Additional review information
It makes sense that render nodes from render instances are disabled following their instance state. But it doesn't make sense for nodes belonging to a template IMO.
If you disable a character to be published through its template instance, you end up with all character nodes disabled... which is very strange, and then you have to reopen the publisher enable it and close it again. In Blender for example, disabling an instance to be published doesn't disable/hide it in the scene and it is much more intuitive.

## Testing notes:
1. Create a render and a template instances
2. Open publisher windows, disable both and close the publisher
