### PR TITLE
Fix: use default for Convert to EXR if publish_attributes empty

### DIFF
--- a/client/ayon_harmony/plugins/publish/extract_convert_to_exr.py
+++ b/client/ayon_harmony/plugins/publish/extract_convert_to_exr.py
@@ -124,6 +124,9 @@ class CollectExrUserOptions(
             .get(cls.__name__, {})
             .get("convert_to_exr")
         )
+        if current_value is None:
+            current_value = default
+
         if (
             current_value == "multichannel_exr"
             and "keep_passes" in cls.user_overrides


### PR DESCRIPTION
## Changelog Description
If refresh is used when `Create multichannel EXR` is already selected it wont return anything in publish_attributes > no Keep passes is shown.


## Testing notes:
1. set `ayon+settings://harmony/publish/ExtractConvertToEXR/multichannel_exr` `Create multichannel EXR` to enabled (this way you are forcing to default state to be enabled)
2. set `Keep render passes` to be in `User overrides` (same Settings)
3. open context portion of Publisher UI, `Keep render passes` toggle should be there even if you will hit `Refresh` button
<img width="1260" height="268" alt="image" src="https://github.com/user-attachments/assets/955f9dda-49bb-4367-8049-c2a3792891fa" />

