### PR TITLE
Delete local folder of old version after publish

### DIFF
--- a/client/ayon_harmony/plugins/publish/increment_workfile.py
+++ b/client/ayon_harmony/plugins/publish/increment_workfile.py
@@ -40,6 +40,7 @@ class IncrementWorkfile(pyblish.api.InstancePlugin):
 
         harmony.save_scene_as(scene_path)
 
+        # Mark unzipped temp workfile to be deleted
         instance.context.data["cleanupFullPaths"].append(current_local_dir)
 
         self.log.info("Incremented workfile to: {}".format(scene_path))


### PR DESCRIPTION
## Changelog Description
If workfile is published and successfully version incremented, original unzipped local folder with previous version is marked to be explicitly deleted as new version is saved in unzipped folder AND zipped and copied to `work` area.

## Additional review information
This solves deletion of last previous version of all newly published files. Question is if there should be some additional plugin to mark all obsolete folders.

## Testing notes:
1. publish workfile 
2. check that subfolder with previous version is deleted in `c:\Users\ynput\.ayon\harmony\`
