### PR TITLE
Fix: Handles range error message

### DIFF
--- a/client/ayon_harmony/plugins/publish/validate_scene_settings.py
+++ b/client/ayon_harmony/plugins/publish/validate_scene_settings.py
@@ -153,7 +153,7 @@ class ValidateSceneSettings(
             )
             and invalid_settings
         ):
-            self.log.error(
+            self.log.info(
                 "Handles included in calculation. Remove handles in DB"
                 " or extend frame range in timeline.\n"
             )


### PR DESCRIPTION
## Changelog Description
Fix handles range error message building failure due to wrong list type usage.

## Testing notes:
1. Change `handle end` of an asset.
2. Open Harmony, run set settings
3. Validate, the error message is displayed and doesn't raise logic error.
