### PR TITLE
🏛️Product base types: Product types and base types

### DIFF
--- a/client/ayon_harmony/api/lib.py
+++ b/client/ayon_harmony/api/lib.py
@@ -27,6 +27,7 @@ from ayon_core.tools.stdout_broker import StdOutBroker
 from ayon_core.tools.utils import host_tools
 from ayon_core import style
 
+# Function 'save_next_version' is used by javascript integration
 from ayon_core.pipeline.workfile import save_next_version  # noqa: F401
 
 from ayon_harmony import HARMONY_ADDON_ROOT

--- a/client/ayon_harmony/api/plugin.py
+++ b/client/ayon_harmony/api/plugin.py
@@ -132,14 +132,19 @@ class HarmonyCreator(Creator, HarmonyCreatorBase):
         ):
             data = scene_data[node_name]
 
-            product_type = data.get("productType")
-            if product_type is None:
-                product_type = data["family"]
-                data["productType"] = product_type
-            data["family"] = product_type
+            product_base_type = data.get("productBaseType")
+            if not product_base_type:
+                product_base_type = data.get("productType")
+                data["productBaseType"] = product_base_type
 
-            instance = CreatedInstance.from_existing(instance_data=data,
-                                                     creator=self)
+            if product_base_type is None:
+                product_base_type = data["family"]
+                data["productType"] = product_base_type
+                data["productBaseType"] = product_base_type
+
+            instance = CreatedInstance.from_existing(
+                instance_data=data, creator=self
+            )
             instance.transient_data["node"] = node_name
 
             # Active state is based of the node's active state

--- a/client/ayon_harmony/api/plugin.py
+++ b/client/ayon_harmony/api/plugin.py
@@ -25,7 +25,7 @@ class HarmonyCreatorBase:
 
         If legacy instances are detected in the scene, create
         `maya_cached_legacy_instances` there and fill it with
-        all legacy products under product type as a key.
+        all legacy products under product base type as a key.
 
         Args:
             Dict[str, Any]: Shared data.
@@ -136,9 +136,10 @@ class HarmonyCreator(Creator, HarmonyCreatorBase):
             product_base_type = data.get("productBaseType")
             if not product_base_type:
                 product_base_type = data.get("productType")
-                data["productBaseType"] = product_base_type
+                if product_base_type:
+                    data["productBaseType"] = product_base_type
 
-            if product_base_type is None:
+            if not product_base_type:
                 product_base_type = data["family"]
                 data["productType"] = product_base_type
                 data["productBaseType"] = product_base_type

--- a/client/ayon_harmony/api/plugin.py
+++ b/client/ayon_harmony/api/plugin.py
@@ -1,3 +1,4 @@
+import collections
 import re
 
 from ayon_core.lib import BoolDef, EnumDef
@@ -30,52 +31,54 @@ class HarmonyCreatorBase:
             Dict[str, Any]: Shared data.
 
         """
-        if shared_data.get("harmony_cached_instance_data") is None:
-            cache = dict()
-            cache_legacy = dict()
+        if shared_data.get("harmony_cached_instance_data") is not None:
+            return shared_data
 
-            # Collect scene data once instead of calling `read()` per node
-            scene_data = harmony.get_scene_data()
-            all_top_names = harmony.get_all_top_names()
-            cleaned_scene_data = False
-            for entity_name, entity_data in reversed(
-                scene_data.copy().items()
-            ):
-                # Filter orphaned instances
-                if entity_name not in all_top_names:
-                    del scene_data[entity_name]
-                    cleaned_scene_data = True
+        cache = dict()
+        cache_legacy = dict()
+
+        # Collect scene data once instead of calling `read()` per node
+        scene_data = harmony.get_scene_data()
+        all_top_names = harmony.get_all_top_names()
+        cleaned_scene_data = False
+        for entity_name, entity_data in reversed(
+            scene_data.copy().items()
+        ):
+            # Filter orphaned instances
+            if entity_name not in all_top_names:
+                del scene_data[entity_name]
+                cleaned_scene_data = True
+                continue
+
+            if entity_data.get("id") not in {
+                AYON_INSTANCE_ID, AVALON_INSTANCE_ID
+            }:
+                continue
+
+            creator_id = entity_data.get("creator_identifier")
+            if creator_id is not None:
+                # creator instance
+                cache.setdefault(creator_id, []).append(entity_name)
+            else:
+                # legacy instance
+                product_type = entity_data.get(
+                    "productType") or entity_data.get("family")
+
+                if product_type is None:
+                    # must be a broken instance
                     continue
 
-                if entity_data.get("id") not in {
-                    AYON_INSTANCE_ID, AVALON_INSTANCE_ID
-                }:
-                    continue
+                cache_legacy.setdefault(product_type, []).append(
+                    entity_name
+                )
 
-                creator_id = entity_data.get("creator_identifier")
-                if creator_id is not None:
-                    # creator instance
-                    cache.setdefault(creator_id, []).append(entity_name)
-                else:
-                    # legacy instance
-                    product_type = entity_data.get(
-                        "productType") or entity_data.get("family")
+        shared_data["harmony_cached_scene_data"] = scene_data
+        shared_data["harmony_cached_instance_data"] = cache
+        shared_data["harmony_cached_legacy_instances_names"] = cache_legacy
 
-                    if product_type is None:
-                        # must be a broken instance
-                        continue
-
-                    cache_legacy.setdefault(product_type, []).append(
-                        entity_name
-                    )
-
-            shared_data["harmony_cached_scene_data"] = scene_data
-            shared_data["harmony_cached_instance_data"] = cache
-            shared_data["harmony_cached_legacy_instances_names"] = cache_legacy
-
-            # Update scene data if cleaned
-            if cleaned_scene_data:
-                harmony.set_scene_data(scene_data)
+        # Update scene data if cleaned
+        if cleaned_scene_data:
+            harmony.set_scene_data(scene_data)
 
         return shared_data
 

--- a/client/ayon_harmony/api/plugin.py
+++ b/client/ayon_harmony/api/plugin.py
@@ -34,8 +34,8 @@ class HarmonyCreatorBase:
         if shared_data.get("harmony_cached_instance_data") is not None:
             return shared_data
 
-        cache = dict()
-        cache_legacy = dict()
+        cache = collections.defaultdict(list)
+        cache_legacy = collections.defaultdict(list)
 
         # Collect scene data once instead of calling `read()` per node
         scene_data = harmony.get_scene_data()
@@ -58,19 +58,19 @@ class HarmonyCreatorBase:
             creator_id = entity_data.get("creator_identifier")
             if creator_id is not None:
                 # creator instance
-                cache.setdefault(creator_id, []).append(entity_name)
-            else:
-                # legacy instance
-                product_type = entity_data.get(
-                    "productType") or entity_data.get("family")
+                cache[creator_id].append(entity_name)
+                continue
 
-                if product_type is None:
-                    # must be a broken instance
-                    continue
+            # legacy instance
+            product_type = (
+                entity_data.get("productType")
+                or entity_data.get("family")
+            )
+            if product_type is None:
+                # must be a broken instance
+                continue
 
-                cache_legacy.setdefault(product_type, []).append(
-                    entity_name
-                )
+            cache_legacy[product_type].append(entity_name)
 
         shared_data["harmony_cached_scene_data"] = scene_data
         shared_data["harmony_cached_instance_data"] = cache
@@ -126,9 +126,11 @@ class HarmonyCreator(Creator, HarmonyCreatorBase):
 
     def collect_instances(self):
         cache = self.cache_instance_data(self.collection_shared_data)
-        for node_name in cache.get("harmony_cached_instance_data").get(
-                self.identifier, []):
-            data = cache.get("harmony_cached_scene_data")[node_name]
+        scene_data = cache["harmony_cached_scene_data"]
+        for node_name in (
+            cache["harmony_cached_instance_data"][self.identifier]
+        ):
+            data = scene_data[node_name]
 
             product_type = data.get("productType")
             if product_type is None:
@@ -393,9 +395,9 @@ class HarmonyAutoCreator(HarmonyCreatorBase, AutoCreator):
 
     def collect_instances(self):
         cache = self.cache_instance_data(self.collection_shared_data)
-        for node in cache.get("harmony_cached_instance_data").get(
-                self.identifier, []):
-            data = cache.get("harmony_cached_scene_data")[node]
+        scene_data = cache["harmony_cached_scene_data"]
+        for node in cache["harmony_cached_instance_data"][self.identifier]:
+            data = scene_data[node]
             created_instance = CreatedInstance.from_existing(data, self)
             created_instance.transient_data["node"] = self._node_name
             self._add_instance_to_context(created_instance)

--- a/client/ayon_harmony/api/plugin.py
+++ b/client/ayon_harmony/api/plugin.py
@@ -40,14 +40,14 @@ class HarmonyCreatorBase:
         # Collect scene data once instead of calling `read()` per node
         scene_data = harmony.get_scene_data()
         all_top_names = harmony.get_all_top_names()
-        cleaned_scene_data = False
+        scene_data_changed = False
         for entity_name, entity_data in reversed(
             scene_data.copy().items()
         ):
             # Filter orphaned instances
             if entity_name not in all_top_names:
                 del scene_data[entity_name]
-                node_data_changed = True
+                scene_data_changed = True
                 continue
 
             if entity_data.get("id") not in {
@@ -78,7 +78,7 @@ class HarmonyCreatorBase:
         shared_data["harmony_cached_legacy_instances_names"] = cache_legacy
 
         # Update scene data if cleaned
-        if cleaned_scene_data:
+        if scene_data_changed:
             harmony.set_scene_data(scene_data)
 
         return shared_data

--- a/client/ayon_harmony/api/plugin.py
+++ b/client/ayon_harmony/api/plugin.py
@@ -99,11 +99,15 @@ class HarmonyCreator(Creator, HarmonyCreatorBase):
         # Create the node
         node = self.product_impl(product_name, instance_data, pre_create_data)
 
+        product_type = instance_data.get("productType")
+        if not product_type:
+            product_type = self.product_base_type
         instance = CreatedInstance(
-            self.product_base_type,
-            product_name,
-            instance_data,
-            self,
+            product_base_type=self.product_base_type,
+            product_type=product_type,
+            product_name=product_name,
+            data=instance_data,
+            creator=self,
         )
         instance.transient_data["node"] = node
         harmony.imprint(node, instance.data_to_store())
@@ -144,9 +148,7 @@ class HarmonyCreator(Creator, HarmonyCreatorBase):
                 data["productType"] = product_base_type
                 data["productBaseType"] = product_base_type
 
-            instance = CreatedInstance.from_existing(
-                instance_data=data, creator=self
-            )
+            instance = CreatedInstance.from_existing(data, self)
             instance.transient_data["node"] = node_name
 
             # Active state is based of the node's active state
@@ -374,10 +376,11 @@ class HarmonyAutoCreator(HarmonyCreatorBase, AutoCreator):
                 f"Auto-creating {self.product_base_type} instance..."
             )
             current_instance = CreatedInstance(
-                self.product_base_type,
-                product_name,
-                data,
-                self,
+                product_base_type=self.product_base_type,
+                product_type=self.product_type,
+                product_name=product_name,
+                data=data,
+                creator=self,
             )
             self._add_instance_to_context(current_instance)
         elif (
@@ -392,6 +395,7 @@ class HarmonyAutoCreator(HarmonyCreatorBase, AutoCreator):
                 task_entity=task_entity,
                 variant=variant,
                 host_name=host_name,
+                product_type=self.product_type,
             )
 
             current_instance["folderPath"] = folder_entity["path"]

--- a/client/ayon_harmony/api/plugin.py
+++ b/client/ayon_harmony/api/plugin.py
@@ -44,15 +44,15 @@ class HarmonyCreatorBase:
         for entity_name, entity_data in reversed(
             scene_data.copy().items()
         ):
+            # Filter orphaned instances
+            if entity_name not in all_top_names:
+                del node_data_by_name[entity_name]
+                node_data_changed = True
+                continue
+
             if entity_data.get("id") not in {
                 AYON_INSTANCE_ID, AVALON_INSTANCE_ID
             }:
-                continue
-
-            # Filter orphaned instances
-            if entity_name not in all_top_names:
-                del scene_data[entity_name]
-                cleaned_scene_data = True
                 continue
 
             creator_id = entity_data.get("creator_identifier")

--- a/client/ayon_harmony/api/plugin.py
+++ b/client/ayon_harmony/api/plugin.py
@@ -62,11 +62,12 @@ class HarmonyCreatorBase:
                 continue
 
             # legacy instance
-            product_type = (
+            product_base_type = (
                 entity_data.get("productType")
                 or entity_data.get("family")
             )
-            if product_type is None:
+
+            if product_base_type is None:
                 # must be a broken instance
                 continue
 

--- a/client/ayon_harmony/api/plugin.py
+++ b/client/ayon_harmony/api/plugin.py
@@ -96,12 +96,18 @@ class HarmonyCreator(Creator, HarmonyCreatorBase):
     settings_category = "harmony"
 
     def create(self, product_name, instance_data, pre_create_data):
+        product_type = instance_data.get("productType")
+        if not product_type:
+            pt_items = self.get_product_type_items()
+            if pt_items:
+                product_type = pt_items[0].product_type
+            else:
+                product_type = self.product_base_type
+            instance_data["productType"] = product_type
+
         # Create the node
         node = self.product_impl(product_name, instance_data, pre_create_data)
 
-        product_type = instance_data.get("productType")
-        if not product_type:
-            product_type = self.product_base_type
         instance = CreatedInstance(
             product_base_type=self.product_base_type,
             product_type=product_type,

--- a/client/ayon_harmony/api/plugin.py
+++ b/client/ayon_harmony/api/plugin.py
@@ -71,7 +71,7 @@ class HarmonyCreatorBase:
                 # must be a broken instance
                 continue
 
-            cache_legacy[product_type].append(entity_name)
+            cache_legacy[product_base_type].append(entity_name)
 
         shared_data["harmony_cached_scene_data"] = scene_data
         shared_data["harmony_cached_instance_data"] = cache

--- a/client/ayon_harmony/api/plugin.py
+++ b/client/ayon_harmony/api/plugin.py
@@ -46,7 +46,7 @@ class HarmonyCreatorBase:
         ):
             # Filter orphaned instances
             if entity_name not in all_top_names:
-                del node_data_by_name[entity_name]
+                del scene_data[entity_name]
                 node_data_changed = True
                 continue
 

--- a/client/ayon_harmony/api/plugin.py
+++ b/client/ayon_harmony/api/plugin.py
@@ -44,15 +44,15 @@ class HarmonyCreatorBase:
         for entity_name, entity_data in reversed(
             scene_data.copy().items()
         ):
+            if entity_data.get("id") not in {
+                AYON_INSTANCE_ID, AVALON_INSTANCE_ID
+            }:
+                continue
+
             # Filter orphaned instances
             if entity_name not in all_top_names:
                 del scene_data[entity_name]
                 cleaned_scene_data = True
-                continue
-
-            if entity_data.get("id") not in {
-                AYON_INSTANCE_ID, AVALON_INSTANCE_ID
-            }:
                 continue
 
             creator_id = entity_data.get("creator_identifier")

--- a/client/ayon_harmony/plugins/create/convert_legacy.py
+++ b/client/ayon_harmony/plugins/create/convert_legacy.py
@@ -11,10 +11,10 @@ class HarmonyLegacyConvertor(ProductConvertorPlugin):
     This Converter will find all legacy products in the scene and will
     transform them to the current system. Since the old products doesn't
     retain any information about their original creators, the only mapping
-    we can do is based on their product types.
+    we can do is based on their product base types.
 
     Its limitation is that you can have multiple creators creating product
-    of the same product type and there is no way to handle it. This code
+    of the same product base type and there is no way to handle it. This code
     should nevertheless cover all creators that came with OpenPype.
 
     """

--- a/client/ayon_harmony/plugins/create/convert_legacy.py
+++ b/client/ayon_harmony/plugins/create/convert_legacy.py
@@ -80,9 +80,10 @@ class HarmonyLegacyConvertor(ProductConvertorPlugin):
                     "id": AYON_INSTANCE_ID,
                     "creator_attributes": {"render_target": "local"}
                 }
-                if product_type == "renderFarm":
+                if product_base_type == "renderFarm":
                     node_meta = self.scene_metadata[node_name]
                     changed_data["productType"] = "render"
+                    changed_data["productBaseType"] = "render"
                     changed_data["productName"] = (
                         node_meta["productName"].replace("Farm", ""))
                     changed_data["creator_attributes"]["render_target"] = \

--- a/client/ayon_harmony/plugins/create/convert_legacy.py
+++ b/client/ayon_harmony/plugins/create/convert_legacy.py
@@ -19,7 +19,7 @@ class HarmonyLegacyConvertor(ProductConvertorPlugin):
 
     """
     identifier = "io.ayon.creators.harmony.legacy"
-    product_type_to_id = {
+    product_base_type_to_id = {
         "render": "io.ayon.creators.harmony.render",
         "renderFarm": "io.ayon.creators.harmony.render",
         "template": "io.ayon.creators.harmony.template",
@@ -64,12 +64,14 @@ class HarmonyLegacyConvertor(ProductConvertorPlugin):
         if not self.legacy_instances:
             return
 
-        for product_type, node_names in self.legacy_instances.items():
-            if product_type not in self.product_type_to_id:
+        for product_base_type, node_names in self.legacy_instances.items():
+            creator_identifier = self.product_base_type_to_id.get(
+                product_base_type
+            )
+            if not creator_identifier:
                 continue
 
             for node_name in node_names:
-                creator_identifier = self.product_type_to_id[product_type]
                 self.log.info(
                     f"Converting {node_name} to {creator_identifier}"
                 )

--- a/client/ayon_harmony/plugins/create/create_render.py
+++ b/client/ayon_harmony/plugins/create/create_render.py
@@ -9,8 +9,8 @@ class CreateRender(plugin.HarmonyRenderCreator):
 
     identifier = "io.ayon.creators.harmony.render"
     label = "Render"
-    product_type = "render"
     product_base_type = "render"
+    product_type = product_base_type
     icon = "eye"
 
     node_type = "WRITE"

--- a/client/ayon_harmony/plugins/create/create_render_layers.py
+++ b/client/ayon_harmony/plugins/create/create_render_layers.py
@@ -695,6 +695,8 @@ class AutoDetectRendeLayersPasses(HarmonyCreator):
         only_visible_groups = pre_create_data.get(
             "only_visible_groups", False
         )
+        layer_product_type = pre_create_data.get("layer_product_type")
+        pass_product_type = pre_create_data.get("pass_product_type")
         filtered_groups = self._filter_groups(
             layers_by_group_id,
             scene_groups,
@@ -712,6 +714,7 @@ class AutoDetectRendeLayersPasses(HarmonyCreator):
                     mark_layers_for_review,
                     render_target,
                     render_layers_by_group_id.get(group.color),
+                    layer_product_type,
                 )
             )
             if instance is not None:
@@ -733,7 +736,8 @@ class AutoDetectRendeLayersPasses(HarmonyCreator):
                 layers,
                 mark_passes_for_review,
                 render_target,
-                render_passes_by_render_layer_id[render_layer_instance.id]
+                render_passes_by_render_layer_id[render_layer_instance.id],
+                pass_product_type,
             )
 
         self._wrap_nodes_in_backdrop()
@@ -791,7 +795,8 @@ class AutoDetectRendeLayersPasses(HarmonyCreator):
         groups: list[GroupInfo],
         mark_for_review: bool,
         render_target: str,
-        existing_instance: Optional[CreatedInstance] = None,
+        existing_instance: Optional[CreatedInstance],
+        layer_product_type: Optional[str],
     ) -> Union[CreatedInstance, None]:
         match_group: Optional[dict[str, Any]] = next(
             (group for group in groups if group.color == group_id), None
@@ -811,12 +816,16 @@ class AutoDetectRendeLayersPasses(HarmonyCreator):
         creator: CreateRenderLayer = self.create_context.creators[
             CreateRenderLayer.identifier
         ]
+        if not layer_product_type:
+            layer_product_type = creator.product_base_type
+
         product_name: str = creator.get_product_name(
             project_entity["name"],
             folder_entity,
             task_entity,
             variant,
             host_name=self.create_context.host_name,
+            product_type=layer_product_type,
             project_entity=project_entity,
         )
         if existing_instance is not None:
@@ -828,7 +837,7 @@ class AutoDetectRendeLayersPasses(HarmonyCreator):
         instance_data: dict[str, str] = {
             "folderPath": folder_entity["path"],
             "task": task_name,
-            "productType": creator.product_base_type,
+            "productType": layer_product_type,
             "productBaseType": creator.product_base_type,
             "variant": variant,
             "group_label": variant
@@ -850,6 +859,7 @@ class AutoDetectRendeLayersPasses(HarmonyCreator):
         mark_for_review: bool,
         render_target: str,
         existing_render_passes: list[CreatedInstance],
+        product_type: Optional[str],
     ):
         task_name = task_entity["name"]
         creator: CreateRenderPass = self.create_context.creators[
@@ -858,6 +868,9 @@ class AutoDetectRendeLayersPasses(HarmonyCreator):
         render_pass_by_layer_name = {}
         for render_pass in existing_render_passes:
             render_pass_by_layer_name[render_pass["layer_name"]] = render_pass
+
+        if not product_type:
+            product_type = creator.product_base_type
 
         # Use renaming template to parse correct variant from existing layer
         #   names.
@@ -927,13 +940,13 @@ class AutoDetectRendeLayersPasses(HarmonyCreator):
                 variant,
                 host_name=self.create_context.host_name,
                 instance=render_pass,
+                product_type=product_type,
                 project_entity=project_entity,
             )
-
             instance_data: dict[str, str] = {
                 "folderPath": folder_entity["path"],
                 "task": task_name,
-                "productType": creator.product_base_type,
+                "productType": product_type,
                 "productBaseType": creator.product_base_type,
                 "variant": variant,
             }
@@ -953,11 +966,12 @@ class AutoDetectRendeLayersPasses(HarmonyCreator):
         render_pass_creator: CreateRenderPass = self.create_context.creators[
             CreateRenderPass.identifier
         ]
-        rendering_targets = {
-            "local": "Local machine rendering",
-            "farm": "Farm rendering",
-        }
-        return [
+        rendering_targets = [
+            {"value": "local", "label": "Local machine rendering"},
+            {"value": "farm", "label": "Farm rendering"},
+        ]
+
+        output = [
             BoolDef(
                 "only_visible_groups",
                 label="Only visible color groups",
@@ -981,8 +995,33 @@ class AutoDetectRendeLayersPasses(HarmonyCreator):
                 "render_target",
                 items=rendering_targets,
                 label="Render target"
-            )
+            ),
         ]
+
+        layer_product_types = [
+            item.product_type
+            for item in render_layer_creator.get_product_type_items()
+        ]
+        if layer_product_types:
+            output.append(EnumDef(
+                "layer_product_type",
+                label="Layer product type",
+                items=layer_product_types,
+                default=layer_product_types[0]
+            ))
+
+        pass_product_types = [
+            item.product_type
+            for item in render_layer_creator.get_product_type_items()
+        ]
+        if pass_product_types:
+            output.append(EnumDef(
+                "pass_product_type",
+                label="Pass product type",
+                items=pass_product_types,
+                default=pass_product_types[0]
+            ))
+        return output
 
     def product_impl(self, name, instance_data: dict, pre_create_data: dict):
         pass

--- a/client/ayon_harmony/plugins/create/create_render_layers.py
+++ b/client/ayon_harmony/plugins/create/create_render_layers.py
@@ -992,7 +992,7 @@ class AutoDetectRendeLayersPasses(HarmonyCreator):
     def get_pre_create_attr_defs(self) -> list[AbstractAttrDef]:
         get_layers_info.cache_clear()
         get_group_infos.cache_clear()
-        
+
         rendering_targets = [
             {"value": "local", "label": "Local machine rendering"},
             {"value": "farm", "label": "Farm rendering"},

--- a/client/ayon_harmony/plugins/create/create_render_layers.py
+++ b/client/ayon_harmony/plugins/create/create_render_layers.py
@@ -257,30 +257,6 @@ class CreateRenderLayer(HarmonyRenderCreator):
             project_entity,
             product_type,
         )
-        task_name = task_type = None
-        if task_entity:
-            task_name = task_entity["name"]
-            task_type = task_entity["taskType"]
-
-        get_product_name_kwargs = {}
-        if getattr(get_product_name, "use_entities", False):
-            if not product_type:
-                product_type = self.product_base_type
-            get_product_name_kwargs.update({
-                "product_type": product_type,
-                "folder_entity": folder_entity,
-                "task_entity": task_entity,
-                "product_base_type": self.product_base_type,
-                "product_base_type_filter": self.product_base_type_filter,
-            })
-        else:
-            get_product_name_kwargs.update({
-                "product_type": self.product_base_type,
-                "task_name": task_name,
-                "task_type": task_type,
-                "product_type_filter": self.product_base_type_filter,
-            })
-
         return get_product_name(
             project_name=project_name,
             host_name=host_name,
@@ -288,7 +264,11 @@ class CreateRenderLayer(HarmonyRenderCreator):
             dynamic_data=dynamic_data,
             project_settings=self.project_settings,
             project_entity=project_entity,
-            **get_product_name_kwargs
+            product_type=product_type,
+            folder_entity=folder_entity,
+            task_entity=task_entity,
+            product_base_type=self.product_base_type,
+            product_base_type_filter=self.product_base_type_filter,
         )
 
     def _create_nodes_for_group(self, group_id, product_name):
@@ -588,38 +568,19 @@ class CreateRenderPass(HarmonyRenderCreator):
             project_entity,
             product_type,
         )
-        task_name = task_type = None
-        if task_entity:
-            task_name = task_entity["name"]
-            task_type = task_entity["taskType"]
-
-        get_product_name_kwargs = {}
-        if getattr(get_product_name, "use_entities", False):
-            if not product_type:
-                product_type = self.product_base_type
-            get_product_name_kwargs.update({
-                "product_type": product_type,
-                "folder_entity": folder_entity,
-                "task_entity": task_entity,
-                "product_base_type": self.product_base_type,
-                "product_base_type_filter": self.product_base_type_filter,
-            })
-        else:
-            get_product_name_kwargs.update({
-                "task_name": task_name,
-                "task_type": task_type,
-                "product_type_filter": self.product_base_type_filter,
-                "product_type": self.product_base_type,
-            })
 
         return get_product_name(
             project_name=project_name,
+            product_base_type=self.product_base_type,
+            product_type=product_type,
+            folder_entity=folder_entity,
+            task_entity=task_entity,
             host_name=host_name,
             variant=variant,
             dynamic_data=dynamic_data,
             project_settings=self.project_settings,
             project_entity=project_entity,
-            **get_product_name_kwargs
+            product_base_type_filter=self.product_base_type_filter,
         )
 
     def _get_render_layers_items(self):

--- a/client/ayon_harmony/plugins/create/create_render_layers.py
+++ b/client/ayon_harmony/plugins/create/create_render_layers.py
@@ -115,8 +115,8 @@ class CreateRenderLayer(HarmonyRenderCreator):
     """
 
     label = "Render Layer"
-    product_type = "render"
     product_base_type = "render"
+    product_type = product_base_type
     product_base_type_filter = "renderLayer"
     identifier = "render.layer"
     icon = "fa5.images"
@@ -322,8 +322,8 @@ class CreateRenderLayer(HarmonyRenderCreator):
 
 
 class CreateRenderPass(HarmonyRenderCreator):
-    product_type = "render"
     product_base_type = "render"
+    product_type = product_base_type
     product_base_type_filter = "renderPass"
     identifier = "render.pass"
     label = "Render Pass"
@@ -621,8 +621,8 @@ class AutoDetectRendeLayersPasses(HarmonyCreator):
     Never will have any instances, all instances belong to different creators.
     """
 
-    product_type = "render"
     product_base_type = "render"
+    product_type = product_base_type
     label = "Render Layer/Passes"
     identifier = "render.auto.detect.creator"
     # order = CreateRenderPass.order + 10

--- a/client/ayon_harmony/plugins/create/create_render_layers.py
+++ b/client/ayon_harmony/plugins/create/create_render_layers.py
@@ -828,7 +828,8 @@ class AutoDetectRendeLayersPasses(HarmonyCreator):
         instance_data: dict[str, str] = {
             "folderPath": folder_entity["path"],
             "task": task_name,
-            "productType": creator.product_type,
+            "productType": creator.product_base_type,
+            "productBaseType": creator.product_base_type,
             "variant": variant,
             "group_label": variant
         }
@@ -932,7 +933,8 @@ class AutoDetectRendeLayersPasses(HarmonyCreator):
             instance_data: dict[str, str] = {
                 "folderPath": folder_entity["path"],
                 "task": task_name,
-                "productType": creator.product_type,
+                "productType": creator.product_base_type,
+                "productBaseType": creator.product_base_type,
                 "variant": variant,
             }
 

--- a/client/ayon_harmony/plugins/create/create_render_layers.py
+++ b/client/ayon_harmony/plugins/create/create_render_layers.py
@@ -695,8 +695,11 @@ class AutoDetectRendeLayersPasses(HarmonyCreator):
         only_visible_groups = pre_create_data.get(
             "only_visible_groups", False
         )
-        layer_product_type = pre_create_data.get("layer_product_type")
-        pass_product_type = pre_create_data.get("pass_product_type")
+        (
+            layer_product_type,
+            pass_product_type
+        ) = self._get_product_types(pre_create_data)
+
         filtered_groups = self._filter_groups(
             layers_by_group_id,
             scene_groups,
@@ -713,8 +716,8 @@ class AutoDetectRendeLayersPasses(HarmonyCreator):
                     filtered_groups,
                     mark_layers_for_review,
                     render_target,
-                    render_layers_by_group_id.get(group.color),
                     layer_product_type,
+                    render_layers_by_group_id.get(group.color),
                 )
             )
             if instance is not None:
@@ -736,11 +739,37 @@ class AutoDetectRendeLayersPasses(HarmonyCreator):
                 layers,
                 mark_passes_for_review,
                 render_target,
-                render_passes_by_render_layer_id[render_layer_instance.id],
                 pass_product_type,
+                render_passes_by_render_layer_id[render_layer_instance.id],
             )
 
         self._wrap_nodes_in_backdrop()
+
+    def _get_render_layer_create_plugin(self) -> CreateRenderLayer:
+        return self.create_context.creators[CreateRenderLayer.identifier]
+
+    def _get_render_pass_create_plugin(self) -> CreateRenderPass:
+        return self.create_context.creators[CreateRenderPass.identifier]
+
+    def _get_product_types(self, pre_create_data: dict) -> tuple[str, str]:
+        layer_product_type = pre_create_data.get("layer_product_type")
+        if not layer_product_type:
+            creator = self._get_render_layer_create_plugin()
+            pt_items = creator.get_product_type_items()
+            if pt_items:
+                layer_product_type = pt_items[0].product_type
+            else:
+                layer_product_type = creator.product_base_type
+
+        pass_product_type = pre_create_data.get("pass_product_type")
+        if not pass_product_type:
+            creator = self._get_render_pass_create_plugin()
+            pt_items = creator.get_product_type_items()
+            if pt_items:
+                pass_product_type = pt_items[0].product_type
+            else:
+                pass_product_type = creator.product_base_type
+        return layer_product_type, pass_product_type
 
     def _filter_groups(
         self,
@@ -795,8 +824,8 @@ class AutoDetectRendeLayersPasses(HarmonyCreator):
         groups: list[GroupInfo],
         mark_for_review: bool,
         render_target: str,
+        product_type: str,
         existing_instance: Optional[CreatedInstance],
-        layer_product_type: Optional[str],
     ) -> Union[CreatedInstance, None]:
         match_group: Optional[dict[str, Any]] = next(
             (group for group in groups if group.color == group_id), None
@@ -813,11 +842,7 @@ class AutoDetectRendeLayersPasses(HarmonyCreator):
             self.group_idx_offset,
             self.log,
         )
-        creator: CreateRenderLayer = self.create_context.creators[
-            CreateRenderLayer.identifier
-        ]
-        if not layer_product_type:
-            layer_product_type = creator.product_base_type
+        creator: CreateRenderLayer = self._get_render_layer_create_plugin()
 
         product_name: str = creator.get_product_name(
             project_entity["name"],
@@ -825,7 +850,6 @@ class AutoDetectRendeLayersPasses(HarmonyCreator):
             task_entity,
             variant,
             host_name=self.create_context.host_name,
-            product_type=layer_product_type,
             project_entity=project_entity,
         )
         if existing_instance is not None:
@@ -837,7 +861,7 @@ class AutoDetectRendeLayersPasses(HarmonyCreator):
         instance_data: dict[str, str] = {
             "folderPath": folder_entity["path"],
             "task": task_name,
-            "productType": layer_product_type,
+            "productType": product_type,
             "productBaseType": creator.product_base_type,
             "variant": variant,
             "group_label": variant
@@ -858,19 +882,14 @@ class AutoDetectRendeLayersPasses(HarmonyCreator):
         layers: list[dict[str, Any]],
         mark_for_review: bool,
         render_target: str,
+        product_type: str,
         existing_render_passes: list[CreatedInstance],
-        product_type: Optional[str],
     ):
         task_name = task_entity["name"]
-        creator: CreateRenderPass = self.create_context.creators[
-            CreateRenderPass.identifier
-        ]
+        creator: CreateRenderPass = self._get_render_pass_create_plugin()
         render_pass_by_layer_name = {}
         for render_pass in existing_render_passes:
             render_pass_by_layer_name[render_pass["layer_name"]] = render_pass
-
-        if not product_type:
-            product_type = creator.product_base_type
 
         # Use renaming template to parse correct variant from existing layer
         #   names.
@@ -960,12 +979,12 @@ class AutoDetectRendeLayersPasses(HarmonyCreator):
             creator.create(product_name, instance_data, pre_create_data)
 
     def get_pre_create_attr_defs(self) -> list[AbstractAttrDef]:
-        render_layer_creator: CreateRenderLayer = self.create_context.creators[
-            CreateRenderLayer.identifier
-        ]
-        render_pass_creator: CreateRenderPass = self.create_context.creators[
-            CreateRenderPass.identifier
-        ]
+        render_layer_creator: CreateRenderLayer = (
+            self._get_render_layer_create_plugin()
+        )
+        render_pass_creator: CreateRenderPass = (
+            self._get_render_pass_create_plugin()
+        )
         rendering_targets = [
             {"value": "local", "label": "Local machine rendering"},
             {"value": "farm", "label": "Farm rendering"},

--- a/client/ayon_harmony/plugins/create/create_review.py
+++ b/client/ayon_harmony/plugins/create/create_review.py
@@ -7,14 +7,14 @@ class CreateReview(HarmonyAutoCreator):
     """Review auto-creator.
 
     It requires `ayon+settings://harmony/create/CreateReview` to be enabled.
-    This creator produces instance of `review` product type, artist does not
-    need create any instance manually if they have a `Top/Display` node
-    in the scene.
+    This creator produces instance of `review` product base type, artist
+    does not need create any instance manually if they have a `Top/Display`
+    node in the scene.
     """
     identifier = "io.ayon.creators.harmony.review"
     label = "Review"
-    product_type = "review"
     product_base_type = "review"
+    product_type = product_base_type
     icon = "ei.video"
 
     default_variants = ["Main"]

--- a/client/ayon_harmony/plugins/create/create_template.py
+++ b/client/ayon_harmony/plugins/create/create_template.py
@@ -11,8 +11,8 @@ class CreateTemplate(plugin.HarmonyCreator):
 
     identifier = "io.ayon.creators.harmony.template"
     label = "Template"
-    product_type = "harmony.template"
     product_base_type = "harmony.template"
+    product_type = product_base_type
     icon = "cubes"
 
     def product_impl(self, name, instance_data: dict, pre_create_data: dict):

--- a/client/ayon_harmony/plugins/create/create_workfile.py
+++ b/client/ayon_harmony/plugins/create/create_workfile.py
@@ -7,8 +7,8 @@ class CreateWorkfile(HarmonyAutoCreator):
     """Workfile auto-creator."""
     identifier = "io.ayon.creators.harmony.workfile"
     label = "Workfile"
-    product_type = "workfile"
     product_base_type = "workfile"
+    product_type = product_base_type
     icon = "fa5.file"
 
     default_variants = ["Main"]

--- a/client/ayon_harmony/plugins/load/load_audio.py
+++ b/client/ayon_harmony/plugins/load/load_audio.py
@@ -33,7 +33,8 @@ function %s(args)
 class ImportAudioLoader(load.LoaderPlugin):
     """Import audio."""
 
-    product_types = {"shot", "audio"}
+    product_base_types = {"shot", "audio"}
+    product_types = product_base_types
     representations = {"wav"}
     label = "Import Audio"
 

--- a/client/ayon_harmony/plugins/load/load_background.py
+++ b/client/ayon_harmony/plugins/load/load_background.py
@@ -230,7 +230,8 @@ class BackgroundLoader(load.LoaderPlugin):
     """Load images
     Stores the imported product in a container named after the product.
     """
-    product_types = {"background"}
+    product_base_types = {"background"}
+    product_types = product_base_types
     representations = {"json"}
 
     def load(self, context, name=None, namespace=None, data=None):

--- a/client/ayon_harmony/plugins/load/load_imagesequence.py
+++ b/client/ayon_harmony/plugins/load/load_imagesequence.py
@@ -17,7 +17,7 @@ class ImageSequenceLoader(load.LoaderPlugin):
     Stores the imported product in a container named after the product.
     """
 
-    product_types = {
+    product_base_types = {
         "shot",
         "render",
         "image",
@@ -25,6 +25,7 @@ class ImageSequenceLoader(load.LoaderPlugin):
         "reference",
         "review",
     }
+    product_types = product_base_types
     representations = {"*"}
     extensions = {"jpeg", "png", "jpg"}
     settings_category = "harmony"

--- a/client/ayon_harmony/plugins/load/load_layers.py
+++ b/client/ayon_harmony/plugins/load/load_layers.py
@@ -7,7 +7,8 @@ import ayon_harmony.api as harmony
 class PsdLoader(harmony.BackdropBaseLoader):
     """Load Photoshop file (.psd)."""
 
-    product_types = {"image"}
+    product_base_types = {"image"}
+    product_types = product_base_types
     representations = {"psd"}
     label = "Load Photoshop Layers"
     icon = "layers"

--- a/client/ayon_harmony/plugins/load/load_palette.py
+++ b/client/ayon_harmony/plugins/load/load_palette.py
@@ -13,7 +13,8 @@ class LinkPaletteLoader(load.LoaderPlugin):
     """
 
     label = "Link Palette"
-    product_types = {"palette", "harmony.palette"}
+    product_base_types = {"palette", "harmony.palette"}
+    product_types = product_base_types
     representations = {"plt"}
     icon = "link"
 

--- a/client/ayon_harmony/plugins/load/load_template.py
+++ b/client/ayon_harmony/plugins/load/load_template.py
@@ -11,7 +11,8 @@ import ayon_harmony.api as harmony
 class TemplateLoader(harmony.BackdropBaseLoader):
     """Load Harmony template as Backdrop container."""
 
-    product_types = {"harmony.template"}
+    product_base_types = {"harmony.template"}
+    product_types = product_base_types
     representations = {"tpl"}
     label = "Load Template"
     icon = "gift"

--- a/client/ayon_harmony/plugins/load/load_template_workfile.py
+++ b/client/ayon_harmony/plugins/load/load_template_workfile.py
@@ -11,7 +11,8 @@ import ayon_harmony.api as harmony
 class ImportTemplateLoader(load.LoaderPlugin):
     """Import Harmony workfiles."""
 
-    product_types = {"workfile"}
+    product_base_types = {"workfile"}
+    product_types = product_base_types
     representations = {"tpl"}
     label = "Import Template"
 
@@ -58,6 +59,7 @@ class ImportTemplateLoader(load.LoaderPlugin):
 class ImportWorkfileLoader(ImportTemplateLoader):
     """Import workfiles."""
 
-    product_types = {"workfile"}
+    product_base_types = {"workfile"}
+    product_types = product_base_types
     representations = {"zip"}
     label = "Import Workfile"

--- a/client/ayon_harmony/plugins/publish/collect_farm_render.py
+++ b/client/ayon_harmony/plugins/publish/collect_farm_render.py
@@ -121,17 +121,30 @@ class CollectFarmRender(publish.AbstractCollectRender):
             task_name = inst.data.get("task")
 
             product_type = inst.data("productType")
+            product_base_type = inst.data("productBaseType")
+            if not product_base_type:
+                product_base_type = product_type
+
             instance_families = inst.data.get("families", [])
 
+            kwargs = dict(
+                productType=product_type,
+                productBaseType=product_base_type,
+            )
+            if "productBaseType" not in attr.fields_dict(
+                HarmonyRenderInstance
+            ):
+                kwargs["productType"] = kwargs.pop("productBaseType")
+
             render_instance = HarmonyRenderInstance(
+                **kwargs,
                 version=version,
                 time=get_formatted_current_time(),
                 source=context.data["currentFile"],
                 name=product_name,
-                label="{} - {}".format(product_name, product_type),
+                label=f"{product_name} - {product_base_type}",
                 productName=product_name,
-                productType=product_type,
-                family=product_type,
+                family=product_base_type,
                 families=instance_families,
                 farm=True,
                 folderPath=folder_path,

--- a/client/ayon_harmony/plugins/publish/collect_farm_render.py
+++ b/client/ayon_harmony/plugins/publish/collect_farm_render.py
@@ -120,24 +120,14 @@ class CollectFarmRender(publish.AbstractCollectRender):
             product_name = inst.data["productName"]
             task_name = inst.data.get("task")
 
-            product_type = inst.data("productType")
-            product_base_type = inst.data("productBaseType")
-            if not product_base_type:
-                product_base_type = product_type
+            product_base_type = inst.data["productBaseType"]
+            product_type = inst.data["productType"]
 
             instance_families = inst.data.get("families", [])
 
-            kwargs = dict(
-                productType=product_type,
-                productBaseType=product_base_type,
-            )
-            if "productBaseType" not in attr.fields_dict(
-                HarmonyRenderInstance
-            ):
-                kwargs["productType"] = kwargs.pop("productBaseType")
-
             render_instance = HarmonyRenderInstance(
-                **kwargs,
+                productBaseType=product_base_type,
+                productType=product_type,
                 version=version,
                 time=get_formatted_current_time(),
                 source=context.data["currentFile"],

--- a/client/ayon_harmony/plugins/publish/collect_instances.py
+++ b/client/ayon_harmony/plugins/publish/collect_instances.py
@@ -16,7 +16,7 @@ class CollectInstances(pyblish.api.InstancePlugin):
     order = pyblish.api.CollectorOrder - 0.4
     hosts = ["harmony"]
 
-    product_type_mapping = {
+    product_base_type_mapping = {
         "render": [],
         "harmony.template": [],
         "palette": ["palette"]
@@ -24,24 +24,25 @@ class CollectInstances(pyblish.api.InstancePlugin):
     pair_media = True
 
     def process(self, instance: pyblish.api.Instance):
-
         # skip render farm product type as it is collected separately
-        product_type = instance.data["productType"]
-        if product_type == "workfile":
+        product_base_type = instance.data["productBaseType"]
+        if product_base_type == "workfile":
             return
 
         node = instance.data["transientData"]["node"]
 
         instance.data["setMembers"] = [node]
 
-        families = [product_type]
+        families = [product_base_type]
 
         creator_attributes = instance.data.get("creator_attributes", {})
-        if product_type == "render":
+        if product_base_type == "render":
             render_target = creator_attributes["render_target"]
             families.append(f"render.{render_target}")
 
-        families.extend(self.product_type_mapping.get(product_type, []))
+        families.extend(
+            self.product_base_type_mapping.get(product_base_type, [])
+        )
 
         mark_for_review = creator_attributes.get("mark_for_review")
         if mark_for_review:
@@ -51,7 +52,7 @@ class CollectInstances(pyblish.api.InstancePlugin):
 
         # If set in plugin, pair the scene Version with
         # thumbnails and review media.
-        if self.pair_media and product_type == "scene":
+        if self.pair_media and product_base_type == "scene":
             instance.context.data["scene_instance"] = instance
 
         # Produce diagnostic message for any graphical

--- a/client/ayon_harmony/plugins/publish/collect_palettes.py
+++ b/client/ayon_harmony/plugins/publish/collect_palettes.py
@@ -43,14 +43,15 @@ class CollectPalettes(pyblish.api.ContextPlugin):
 
         folder_path = context.data["folderPath"]
 
-        product_type = "harmony.palette"
+        product_base_type = "harmony.palette"
         for name, palette_id in palettes.items():
             instance = context.create_instance(name)
             instance.data.update({
                 "id": palette_id,
-                "productType": product_type,
-                "family": product_type,
-                "families": [product_type],
+                "productType": product_base_type,
+                "productBaseType": product_base_type,
+                "family": product_base_type,
+                "families": [product_base_type],
                 "folderPath": folder_path,
                 # TODO use product name template to calculate product name
                 "productName": f"palette{name}"

--- a/client/ayon_harmony/plugins/publish/extract_review_source.py
+++ b/client/ayon_harmony/plugins/publish/extract_review_source.py
@@ -28,7 +28,8 @@ class ExtractSourceForReview(publish.Extractor):
 
     def process(self, instance):
         """Plugin entry point."""
-        if instance.data["productType"] != "review":
+        product_base_type = instance.data["productBaseType"]
+        if product_base_type != "review":
             self.log.info("Not primary `review` product type, skipping.")
             return
 

--- a/client/ayon_harmony/plugins/publish/help/validate_review_source.xml
+++ b/client/ayon_harmony/plugins/publish/help/validate_review_source.xml
@@ -5,7 +5,7 @@
 <description>
 ## Top/Display node expected
 
-Export of `review` product type expects Display node with `Top/Display` identifier.
+Export of `review` product base type expects Display node with `Top/Display` identifier.
 
 ### How to repair?
 

--- a/client/ayon_harmony/plugins/publish/validate_review_source.py
+++ b/client/ayon_harmony/plugins/publish/validate_review_source.py
@@ -23,7 +23,8 @@ class ValidateTopDisplay(pyblish.api.InstancePlugin):
     settings_category = "harmony"
 
     def process(self, instance):
-        if instance.data["productType"] != "review":
+        product_base_type = instance.data["productBaseType"]
+        if product_base_type != "review":
             self.log.debug("Not primary `review` product type, skipping.")
             return
 

--- a/server/settings/creator_plugins.py
+++ b/server/settings/creator_plugins.py
@@ -1,6 +1,20 @@
 from ayon_server.settings import BaseSettingsModel, SettingsField
 
 
+
+class ProductTypeItemModel(BaseSettingsModel):
+    _layout = "compact"
+    product_type: str = SettingsField(
+        title="Product type",
+        description="Product type name",
+    )
+    label: str = SettingsField(
+        "",
+        title="Label",
+        description="Label to display in UI for the product type",
+    )
+
+
 class CreateRenderPluginModel(BaseSettingsModel):
     enabled: bool = SettingsField(True, title="Enabled")
     active_on_create: bool = SettingsField(True, title="Active by default")
@@ -15,6 +29,13 @@ class CreateRenderPluginModel(BaseSettingsModel):
         title="Regex pattern for Composite node name",
         description="Provide regex pattern to find Composite node to "
                     "connect newly Write node to"
+    )
+    product_type_items: list[ProductTypeItemModel] = SettingsField(
+        default_factory=list,
+        title="Product type items",
+        description=(
+            "Optional list of product types that this plugin can create."
+        )
     )
 
 
@@ -48,6 +69,13 @@ class CreateRenderLayerModel(BaseSettingsModel):
     default_variants: list[str] = SettingsField(
         default_factory=list, title="Default variants"
     )
+    product_type_items: list[ProductTypeItemModel] = SettingsField(
+        default_factory=list,
+        title="Product type items",
+        description=(
+            "Optional list of product types that this plugin can create."
+        )
+    )
 
 
 class CreateRenderPassModel(BaseSettingsModel):
@@ -73,6 +101,13 @@ class CreateRenderPassModel(BaseSettingsModel):
     )
     layer_idx_padding: int = SettingsField(
         3, title="Layer index Padding", ge=0
+    )
+    product_type_items: list[ProductTypeItemModel] = SettingsField(
+        default_factory=list,
+        title="Product type items",
+        description=(
+            "Optional list of product types that this plugin can create."
+        )
     )
 
 

--- a/server/settings/creator_plugins.py
+++ b/server/settings/creator_plugins.py
@@ -1,7 +1,6 @@
 from ayon_server.settings import BaseSettingsModel, SettingsField
 
 
-
 class ProductTypeItemModel(BaseSettingsModel):
     _layout = "compact"
     product_type: str = SettingsField(


### PR DESCRIPTION
## Changelog Description
Use product base types and add support for product types used as aliases.

## Additional review information
Harmony is fully using product base type as "pipeline" type and product type as an alias. Load plugins define `product_base_types` for filtering, create plugins do define `product_base_type` and the whole logic is expecting that product base type is being used in the system. Render create plugins can define custom product types.

## Testing notes:
1. Define product types for a a render create plugin.
2. Create an instance with the product type.
3. Product name should use the product type in name (if template defines that).
4. Publish the instance.
5. Loader tool should show the product type and product base type in UI.
6. Autocreator should give an option to choose from available product types (if they are defined on render layer or render pass create plugin settings).