### PR TITLE
Loaders: Filters by extension instead of representation name

### DIFF
--- a/client/ayon_harmony/plugins/load/load_audio.py
+++ b/client/ayon_harmony/plugins/load/load_audio.py
@@ -34,7 +34,8 @@ class ImportAudioLoader(load.LoaderPlugin):
     """Import audio."""
 
     product_types = {"shot", "audio"}
-    representations = {"wav"}
+    representations = {"*"}
+    extensions = {"wav"}
     label = "Import Audio"
 
     def load(self, context, name=None, namespace=None, data=None):

--- a/client/ayon_harmony/plugins/load/load_background.py
+++ b/client/ayon_harmony/plugins/load/load_background.py
@@ -231,7 +231,8 @@ class BackgroundLoader(load.LoaderPlugin):
     Stores the imported product in a container named after the product.
     """
     product_types = {"background"}
-    representations = {"json"}
+    representations = {"*"}
+    extensions = {"json"}
 
     def load(self, context, name=None, namespace=None, data=None):
 

--- a/client/ayon_harmony/plugins/load/load_layers.py
+++ b/client/ayon_harmony/plugins/load/load_layers.py
@@ -8,6 +8,7 @@ class PsdLoader(harmony.BackdropBaseLoader):
     """Load Photoshop file (.psd)."""
 
     product_types = {"image"}
-    representations = {"psd"}
+    representations = {"*"}
+    extensions = {"psd"}
     label = "Load Photoshop Layers"
     icon = "layers"

--- a/client/ayon_harmony/plugins/load/load_palette.py
+++ b/client/ayon_harmony/plugins/load/load_palette.py
@@ -14,7 +14,8 @@ class LinkPaletteLoader(load.LoaderPlugin):
 
     label = "Link Palette"
     product_types = {"palette", "harmony.palette"}
-    representations = {"plt"}
+    representations = {"*"}
+    extensions = {"plt"}
     icon = "link"
 
     def load(self, context, name=None, namespace=None, data=None):

--- a/client/ayon_harmony/plugins/load/load_palette.py
+++ b/client/ayon_harmony/plugins/load/load_palette.py
@@ -101,7 +101,8 @@ class ImportPaletteLoader(LinkPaletteLoader):
     """
 
     label = "Import Palette"
-    representations = {"plt"}
+    representations = {"*"}
+    extensions = {"plt"}
     icon = "gift"
     order = 0.1
 

--- a/client/ayon_harmony/plugins/load/load_template.py
+++ b/client/ayon_harmony/plugins/load/load_template.py
@@ -12,7 +12,8 @@ class TemplateLoader(harmony.BackdropBaseLoader):
     """Load Harmony template as Backdrop container."""
 
     product_types = {"harmony.template"}
-    representations = {"tpl"}
+    representations = {"*"}
+    extensions = {"tpl"}
     label = "Load Template"
     icon = "gift"
 

--- a/client/ayon_harmony/plugins/load/load_template.py
+++ b/client/ayon_harmony/plugins/load/load_template.py
@@ -13,7 +13,7 @@ class TemplateLoader(harmony.BackdropBaseLoader):
 
     product_types = {"harmony.template"}
     representations = {"*"}
-    extensions = {"tpl"}
+    extensions = {"zip"}
     label = "Load Template"
     icon = "gift"
 

--- a/client/ayon_harmony/plugins/load/load_template_workfile.py
+++ b/client/ayon_harmony/plugins/load/load_template_workfile.py
@@ -60,5 +60,6 @@ class ImportWorkfileLoader(ImportTemplateLoader):
     """Import workfiles."""
 
     product_types = {"workfile"}
-    representations = {"zip"}
+    representations = {"*"}
+    extensions = {"zip"}
     label = "Import Workfile"

--- a/client/ayon_harmony/plugins/load/load_template_workfile.py
+++ b/client/ayon_harmony/plugins/load/load_template_workfile.py
@@ -12,7 +12,8 @@ class ImportTemplateLoader(load.LoaderPlugin):
     """Import Harmony workfiles."""
 
     product_types = {"workfile"}
-    representations = {"tpl"}
+    representations = {"*"}
+    extensions = {"tpl"}
     label = "Import Template"
 
     def load(self, context, name=None, namespace=None, data=None):


### PR DESCRIPTION
## Changelog Description

Loaders: Filters by extension instead of representation name

## Additional review information

Make loaders filter by extension instead of representation name so they are less restrictive on what can be loaded.

## Testing notes:

1. Validate code changes
2. Loaders should still be able to load the right representations, etc.