### PR TITLE
Track copy pasted templates

### DIFF
--- a/client/ayon_harmony/api/__init__.py
+++ b/client/ayon_harmony/api/__init__.py
@@ -14,6 +14,7 @@ from .pipeline import (
     application_launch,
     export_backdrop_as_template,
     inject_ayon_js,
+    ensure_metadata_in_backdrop,
 )
 
 from .lib import (
@@ -61,6 +62,7 @@ __all__ = [
     "application_launch",
     "export_backdrop_as_template",
     "inject_ayon_js",
+    "ensure_metadata_in_backdrop",
 
     # lib
     "launch",

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -363,10 +363,10 @@ def ls():
     }
     returnNodeAttr"""
 
-    note_node_text = harmony.send({"function": func})["result"]
+    note_node_texts = harmony.send({"function": func})["result"]
 
     note_dict = {}
-    for note in note_node_text:
+    for note in note_node_texts:
         note_dict |= ast.literal_eval(note)
 
     for entity_name, entity_data in note_dict.items():

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -321,8 +321,8 @@ def is_container_data(data: dict) -> bool:
     return data and data.get("id") in {AYON_CONTAINER_ID, AVALON_CONTAINER_ID}
 
 
-def get_metadata_from_note()-> dict:
-    """Get metadata of templates from note nodes and return them as a dictionary.
+def read_metadata_from_notes() -> dict:
+    """Read metadata of templates from note nodes and return them as a dictionary.
 
     Returns:
         dict: Dictionary with metadata.
@@ -332,7 +332,7 @@ def get_metadata_from_note()-> dict:
     var nodes = node.getNodes(["NOTE"]);
     var results = [];
     for (var i = 0; i < nodes.length; i++) {
-        if (nodes[i].split("-")[0] === "Top/templateID") {
+        if (nodes[i].indexOf("Top/ayon-metadata") !== -1) {
             var data = node.getTextAttr(nodes[i], 1.0, "text");
             results.push(data);
             }
@@ -379,7 +379,7 @@ def ls():
             entity_data["objectName"] = entity_data["name"]
         yield entity_data
 
-    metadata = get_metadata_from_note()
+    metadata = read_metadata_from_notes()
 
     for entity_name, entity_data in metadata.items():
         if entity_name not in scene_data:

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import Path
 import logging
-
+import ast
 import pyblish.api
 
 from ayon_core.lib import register_event_callback
@@ -43,8 +43,6 @@ LOAD_PATH = os.path.join(PLUGINS_DIR, "load")
 CREATE_PATH = os.path.join(PLUGINS_DIR, "create")
 INVENTORY_PATH = os.path.join(PLUGINS_DIR, "inventory")
 
-script_dir = Path(__file__).parent
-LOG = f"{script_dir}" + "/LOG.txt"
 
 class HarmonyHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
     name = "harmony"
@@ -258,7 +256,7 @@ def ls():
         harmony.get_all_top_names() | harmony.get_palettes_paths()
     )
 
-    cleaned_scene_data = False
+    updated_scene_data = False
     for entity_name, entity_data in scene_data.copy().items():
         if not is_container_data(entity_data):
             continue
@@ -266,46 +264,39 @@ def ls():
         # Filter orphaned containers
         if entity_name not in containers_names:
             del scene_data[entity_name]
-            cleaned_scene_data = True
+            updated_scene_data = True
             continue
 
         if not entity_data.get("objectName"):  # backward compatibility
             entity_data["objectName"] = entity_data["name"]
         yield entity_data
 
-    # nodes = harmony.send(
-    #     {"function": "node.getNodes", "args": ["NOTE"]}
-    # )["result"]
-
-    # for node in nodes:
-    #     if node.split("-")[0] == "Top/templateID":
-    #         data = harmony.send(
-    #             {"function": "node.getTextAttr", "args": [node, 1.0, "text"]}
-    #         )["result"]
-    #         break
-    
+    # to look for new containers pasted to the scene
     func = """function returnNodeAttr() {
     var nodes = node.getNodes(["NOTE"]);
+    var results = [];
     for (var i = 0; i < nodes.length; i++) {
         if (nodes[i].split("-")[0] === "Top/templateID") {
-            return node.getTextAttr(nodes[i], 1.0, "text");
+            var data = node.getTextAttr(nodes[i], 1.0, "text");
+            results.push(data);
+            }
         }
-    }
-    return null;
+        return results;
     }
     returnNodeAttr"""
 
-    data = harmony.send({"function": func})["result"]
+    note_node_text = harmony.send({"function": func})["result"]
 
-    with open(LOG, "a") as f:
-        f.write(f"#################\n")
-        f.write(f"get_all_top_names : {harmony.get_all_top_names()}\n")
-        f.write(f"containers_names : {containers_names}\n")
-        f.write(f"scene_data : {scene_data}\n")
-        f.write(f"data : {data}\n")
-        
-    # Update scene data if cleaned
-    if cleaned_scene_data:
+    note_dict = {}
+    for note in note_node_text:
+        note_dict |= ast.literal_eval(note)
+
+    for entity_name, entity_data in note_dict.items():
+        if entity_name not in scene_data:
+            updated_scene_data = True
+            scene_data[entity_name] = entity_data
+
+    if updated_scene_data:
         harmony.set_scene_data(scene_data)
 
 

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -320,14 +320,15 @@ def is_container_data(data: dict) -> bool:
     """Return whether data is container data."""
     return data and data.get("id") in {AYON_CONTAINER_ID, AVALON_CONTAINER_ID}
 
-def read_note_nodes():
+
+def read_note_nodes() -> dict:
     """Read all note nodes containing metadata in the scene and return text as a dictionary.
 
     Returns:
         dict: Dictionary with metadata.
 
     """
-    
+
     func = """function returnNodeAttr() {
     var nodes = node.getNodes(["NOTE"]);
     var results = [];

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -320,11 +320,41 @@ def is_container_data(data: dict) -> bool:
     """Return whether data is container data."""
     return data and data.get("id") in {AYON_CONTAINER_ID, AVALON_CONTAINER_ID}
 
+def read_note_nodes():
+    """Read all note nodes containing metadata in the scene and return text as a dictionary.
+
+    Returns:
+        dict: Dictionary with metadata.
+
+    """
+    
+    func = """function returnNodeAttr() {
+    var nodes = node.getNodes(["NOTE"]);
+    var results = [];
+    for (var i = 0; i < nodes.length; i++) {
+        if (nodes[i].split("-")[0] === "Top/templateID") {
+            var data = node.getTextAttr(nodes[i], 1.0, "text");
+            results.push(data);
+            }
+        }
+        return results;
+    }
+    returnNodeAttr"""
+
+    metadata_list = harmony.send({"function": func})["result"]
+
+    metadata_dict = {}
+    for note in metadata_list:
+        metadata_dict |= ast.literal_eval(note)
+
+    return metadata_dict
+
 
 def ls():
     """Yields containers from Harmony scene.
 
     Clean up scene data from orphaned containers.
+    look for note nodes with metadata and add them to scene data if not registered.
 
     Yields:
         dict: container
@@ -349,27 +379,9 @@ def ls():
             entity_data["objectName"] = entity_data["name"]
         yield entity_data
 
-    # to look for new containers pasted to the scene
-    func = """function returnNodeAttr() {
-    var nodes = node.getNodes(["NOTE"]);
-    var results = [];
-    for (var i = 0; i < nodes.length; i++) {
-        if (nodes[i].split("-")[0] === "Top/templateID") {
-            var data = node.getTextAttr(nodes[i], 1.0, "text");
-            results.push(data);
-            }
-        }
-        return results;
-    }
-    returnNodeAttr"""
+    metadata = read_note_nodes()
 
-    note_node_texts = harmony.send({"function": func})["result"]
-
-    note_dict = {}
-    for note in note_node_texts:
-        note_dict |= ast.literal_eval(note)
-
-    for entity_name, entity_data in note_dict.items():
+    for entity_name, entity_data in metadata.items():
         if entity_name not in scene_data:
             updated_scene_data = True
             scene_data[entity_name] = entity_data

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -321,12 +321,11 @@ def is_container_data(data: dict) -> bool:
     return data and data.get("id") in {AYON_CONTAINER_ID, AVALON_CONTAINER_ID}
 
 
-def read_note_nodes() -> dict:
-    """Read all note nodes containing metadata in the scene and return text as a dictionary.
+def get_metadata_from_note()-> dict:
+    """Get metadata of templates from note nodes and return them as a dictionary.
 
     Returns:
-        dict: Dictionary with metadata.
-
+        dict[str, dict]: Dictionary with metadata.
     """
 
     func = """function returnNodeAttr() {
@@ -380,12 +379,13 @@ def ls():
             entity_data["objectName"] = entity_data["name"]
         yield entity_data
 
-    metadata = read_note_nodes()
+    metadata = get_metadata_from_note()
 
     for entity_name, entity_data in metadata.items():
         if entity_name not in scene_data:
             updated_scene_data = True
             scene_data[entity_name] = entity_data
+        yield entity_data
 
     if updated_scene_data:
         harmony.set_scene_data(scene_data)

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -43,6 +43,8 @@ LOAD_PATH = os.path.join(PLUGINS_DIR, "load")
 CREATE_PATH = os.path.join(PLUGINS_DIR, "create")
 INVENTORY_PATH = os.path.join(PLUGINS_DIR, "inventory")
 
+script_dir = Path(__file__).parent
+LOG = f"{script_dir}" + "/LOG.txt"
 
 class HarmonyHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
     name = "harmony"
@@ -243,7 +245,7 @@ def is_container_data(data: dict) -> bool:
     return data and data.get("id") in {AYON_CONTAINER_ID, AVALON_CONTAINER_ID}
 
 
-def ls(): 
+def ls():
     """Yields containers from Harmony scene.
 
     Clean up scene data from orphaned containers.
@@ -255,6 +257,7 @@ def ls():
     containers_names = (
         harmony.get_all_top_names() | harmony.get_palettes_paths()
     )
+
     cleaned_scene_data = False
     for entity_name, entity_data in scene_data.copy().items():
         if not is_container_data(entity_data):
@@ -270,6 +273,37 @@ def ls():
             entity_data["objectName"] = entity_data["name"]
         yield entity_data
 
+    # nodes = harmony.send(
+    #     {"function": "node.getNodes", "args": ["NOTE"]}
+    # )["result"]
+
+    # for node in nodes:
+    #     if node.split("-")[0] == "Top/templateID":
+    #         data = harmony.send(
+    #             {"function": "node.getTextAttr", "args": [node, 1.0, "text"]}
+    #         )["result"]
+    #         break
+    
+    func = """function returnNodeAttr() {
+    var nodes = node.getNodes(["NOTE"]);
+    for (var i = 0; i < nodes.length; i++) {
+        if (nodes[i].split("-")[0] === "Top/templateID") {
+            return node.getTextAttr(nodes[i], 1.0, "text");
+        }
+    }
+    return null;
+    }
+    returnNodeAttr"""
+
+    data = harmony.send({"function": func})["result"]
+
+    with open(LOG, "a") as f:
+        f.write(f"#################\n")
+        f.write(f"get_all_top_names : {harmony.get_all_top_names()}\n")
+        f.write(f"containers_names : {containers_names}\n")
+        f.write(f"scene_data : {scene_data}\n")
+        f.write(f"data : {data}\n")
+        
     # Update scene data if cleaned
     if cleaned_scene_data:
         harmony.set_scene_data(scene_data)

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -332,7 +332,7 @@ def read_metadata_from_notes() -> dict:
     var nodes = node.getNodes(["NOTE"]);
     var results = [];
     for (var i = 0; i < nodes.length; i++) {
-        if (nodes[i].indexOf("Top/ayon-metadata") !== -1) {
+        if (nodes[i].indexOf("ayon-metadata") !== -1) {
             var data = node.getTextAttr(nodes[i], 1.0, "text");
             results.push(data);
             }

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -10,10 +10,7 @@ from ayon_core.tools.utils.host_tools import (
     show_workfiles,
 )
 
-from ayon_core.tools.utils.host_tools import show_scene_inventory
-
-import ast
-
+import json
 
 import pyblish.api
 
@@ -54,6 +51,8 @@ from .workio import (
     file_extensions,
     work_root
 )
+
+log_path = r"C:\Users\normaal\Documents\YuanDev\AYON-Development-Workbench\ayon-harmony\LOG.txt"
 
 log = logging.getLogger("ayon_harmony")
 
@@ -104,6 +103,8 @@ class HarmonyHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         return file_extensions()
 
     def get_containers(self):
+        with open(log_path, "a") as f:
+            f.write("@@@@@@@ get_containers\n")
         return ls()
 
     def get_context_data(self):
@@ -321,46 +322,72 @@ def is_container_data(data: dict) -> bool:
     return data and data.get("id") in {AYON_CONTAINER_ID, AVALON_CONTAINER_ID}
 
 
-def read_metadata_from_notes() -> dict:
-    """Read metadata of templates from note nodes and return them as a dictionary.
-
+def read_metadata_from_backdrops() -> dict:
+    """Read metadata of templates from backdrop description fields.
+    
+    Looks for backdrops containing '<AYON_METADATA/>' marker in their
+    description text and parses the JSON metadata that follows.
+    
     Returns:
         dict: Dictionary with metadata.
     """
-
-    func = """function returnNodeAttr() {
-    var nodes = node.getNodes(["NOTE"]);
-    var results = [];
-    for (var i = 0; i < nodes.length; i++) {
-        if (nodes[i].indexOf("ayon-metadata") !== -1) {
-            var data = node.getTextAttr(nodes[i], 1.0, "text");
-            results.push(data);
+    func = """function readBackdropMetadata() {
+        var backdrops = Backdrop.backdrops("Top");
+        var results = [];
+        for (var i = 0; i < backdrops.length; i++) {
+            var desc = backdrops[i].description.text || "";
+            var marker = "<AYON_METADATA/>";
+            var markerIndex = desc.indexOf(marker);
+            if (markerIndex !== -1) {
+                var jsonStr = desc.substring(markerIndex + marker.length).trim();
+                results.push(jsonStr);
             }
         }
         return results;
     }
-    returnNodeAttr"""
-
+    readBackdropMetadata"""
+    
     metadata_list = harmony.send({"function": func})["result"]
-
     metadata_dict = {}
-    for note in metadata_list:
-        metadata_dict |= ast.literal_eval(note)
-
+    for entry in metadata_list:
+        metadata_dict |= json.loads(entry)
     return metadata_dict
+
+def ensure_metadata_in_backdrop(backdrop_name: str, metadata: dict):
+    metadata_json = json.dumps(metadata).replace('"', '\\"')
+    separator = "\\n" * 100
+    harmony.send(
+        {
+            "script": f"""
+    var backdrops = Backdrop.backdrops("Top");
+    for (var i = 0; i < backdrops.length; i++) {{
+        if (backdrops[i].title.text === "{backdrop_name}") {{
+            var currentText = backdrops[i].description.text || "";
+            var marker = "<AYON_METADATA/>";
+            var markerIndex = currentText.indexOf(marker);
+            if (markerIndex === -1) {{
+                backdrops[i].description.text = currentText + marker + "\\n" + "{metadata_json}";
+                Backdrop.setBackdrops("Top", backdrops);
+                MessageLog.trace("Metadata ensured in backdrop: " + backdrops[i].title.text);
+            }}
+        }}
+    }}
+    """
+        }
+    )
 
 
 def ls():
     """Yields containers from Harmony scene.
 
     Clean up scene data from orphaned containers.
-
-    Look for note nodes with metadata and add them to scene data if not registered.
-
+    Look for backdrop metadata and add them to scene data if not registered.
     Yields:
         dict: container
     """
     scene_data = harmony.get_scene_data() or dict()
+    with open(log_path, "a") as f:
+        f.write(f"@@@@@@@ scene_data {scene_data}\n")
     containers_names = (
         harmony.get_all_top_names() | harmony.get_palettes_paths()
     )
@@ -380,13 +407,23 @@ def ls():
             entity_data["objectName"] = entity_data["name"]
         yield entity_data
 
-    metadata = read_metadata_from_notes()
+    METADATA_EXCLUDED_KEYS = {"nodes", "objectName"}
 
+    for entity_name, entity_data in scene_data.items():
+        if is_container_data(entity_data):
+            clean_data = {k: v for k, v in entity_data.items() 
+                        if k not in METADATA_EXCLUDED_KEYS}
+            ensure_metadata_in_backdrop(entity_name, {entity_name: clean_data})
+        
+    metadata = read_metadata_from_backdrops()
     for entity_name, entity_data in metadata.items():
         if entity_name not in scene_data:
             updated_scene_data = True
             scene_data[entity_name] = entity_data
         yield entity_data
+
+    with open(log_path, "a") as f:
+        f.write(f"@@@@@@@ updated_scene_data {updated_scene_data}\n")
 
     if updated_scene_data:
         harmony.set_scene_data(scene_data)

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -354,7 +354,8 @@ def ls():
     """Yields containers from Harmony scene.
 
     Clean up scene data from orphaned containers.
-    look for note nodes with metadata and add them to scene data if not registered.
+
+    Look for note nodes with metadata and add them to scene data if not registered.
 
     Yields:
         dict: container

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -325,7 +325,7 @@ def get_metadata_from_note()-> dict:
     """Get metadata of templates from note nodes and return them as a dictionary.
 
     Returns:
-        dict[str, dict]: Dictionary with metadata.
+        dict: Dictionary with metadata.
     """
 
     func = """function returnNodeAttr() {

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -9,6 +9,12 @@ from ayon_core.tools.utils.host_tools import (
     show_scene_inventory,
     show_workfiles,
 )
+
+from ayon_core.tools.utils.host_tools import show_scene_inventory
+
+import ast
+
+
 import pyblish.api
 
 from ayon_core.lib import is_headless_mode_enabled, register_event_callback
@@ -57,8 +63,6 @@ LOAD_PATH = os.path.join(PLUGINS_DIR, "load")
 CREATE_PATH = os.path.join(PLUGINS_DIR, "create")
 INVENTORY_PATH = os.path.join(PLUGINS_DIR, "inventory")
 
-script_dir = Path(__file__).parent
-LOG = f"{script_dir}" + "/LOG.txt"
 
 class HarmonyHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
     name = "harmony"
@@ -330,7 +334,7 @@ def ls():
         harmony.get_all_top_names() | harmony.get_palettes_paths()
     )
 
-    cleaned_scene_data = False
+    updated_scene_data = False
     for entity_name, entity_data in scene_data.copy().items():
         if not is_container_data(entity_data):
             continue
@@ -338,46 +342,39 @@ def ls():
         # Filter orphaned containers
         if entity_name not in containers_names:
             del scene_data[entity_name]
-            cleaned_scene_data = True
+            updated_scene_data = True
             continue
 
         if not entity_data.get("objectName"):  # backward compatibility
             entity_data["objectName"] = entity_data["name"]
         yield entity_data
 
-    # nodes = harmony.send(
-    #     {"function": "node.getNodes", "args": ["NOTE"]}
-    # )["result"]
-
-    # for node in nodes:
-    #     if node.split("-")[0] == "Top/templateID":
-    #         data = harmony.send(
-    #             {"function": "node.getTextAttr", "args": [node, 1.0, "text"]}
-    #         )["result"]
-    #         break
-    
+    # to look for new containers pasted to the scene
     func = """function returnNodeAttr() {
     var nodes = node.getNodes(["NOTE"]);
+    var results = [];
     for (var i = 0; i < nodes.length; i++) {
         if (nodes[i].split("-")[0] === "Top/templateID") {
-            return node.getTextAttr(nodes[i], 1.0, "text");
+            var data = node.getTextAttr(nodes[i], 1.0, "text");
+            results.push(data);
+            }
         }
-    }
-    return null;
+        return results;
     }
     returnNodeAttr"""
 
-    data = harmony.send({"function": func})["result"]
+    note_node_text = harmony.send({"function": func})["result"]
 
-    with open(LOG, "a") as f:
-        f.write(f"#################\n")
-        f.write(f"get_all_top_names : {harmony.get_all_top_names()}\n")
-        f.write(f"containers_names : {containers_names}\n")
-        f.write(f"scene_data : {scene_data}\n")
-        f.write(f"data : {data}\n")
-        
-    # Update scene data if cleaned
-    if cleaned_scene_data:
+    note_dict = {}
+    for note in note_node_text:
+        note_dict |= ast.literal_eval(note)
+
+    for entity_name, entity_data in note_dict.items():
+        if entity_name not in scene_data:
+            updated_scene_data = True
+            scene_data[entity_name] = entity_data
+
+    if updated_scene_data:
         harmony.set_scene_data(scene_data)
 
 

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -243,7 +243,7 @@ def is_container_data(data: dict) -> bool:
     return data and data.get("id") in {AYON_CONTAINER_ID, AVALON_CONTAINER_ID}
 
 
-def ls():
+def ls(): 
     """Yields containers from Harmony scene.
 
     Clean up scene data from orphaned containers.

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -57,6 +57,8 @@ LOAD_PATH = os.path.join(PLUGINS_DIR, "load")
 CREATE_PATH = os.path.join(PLUGINS_DIR, "create")
 INVENTORY_PATH = os.path.join(PLUGINS_DIR, "inventory")
 
+script_dir = Path(__file__).parent
+LOG = f"{script_dir}" + "/LOG.txt"
 
 class HarmonyHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
     name = "harmony"
@@ -315,7 +317,7 @@ def is_container_data(data: dict) -> bool:
     return data and data.get("id") in {AYON_CONTAINER_ID, AVALON_CONTAINER_ID}
 
 
-def ls(): 
+def ls():
     """Yields containers from Harmony scene.
 
     Clean up scene data from orphaned containers.
@@ -327,6 +329,7 @@ def ls():
     containers_names = (
         harmony.get_all_top_names() | harmony.get_palettes_paths()
     )
+
     cleaned_scene_data = False
     for entity_name, entity_data in scene_data.copy().items():
         if not is_container_data(entity_data):
@@ -342,6 +345,37 @@ def ls():
             entity_data["objectName"] = entity_data["name"]
         yield entity_data
 
+    # nodes = harmony.send(
+    #     {"function": "node.getNodes", "args": ["NOTE"]}
+    # )["result"]
+
+    # for node in nodes:
+    #     if node.split("-")[0] == "Top/templateID":
+    #         data = harmony.send(
+    #             {"function": "node.getTextAttr", "args": [node, 1.0, "text"]}
+    #         )["result"]
+    #         break
+    
+    func = """function returnNodeAttr() {
+    var nodes = node.getNodes(["NOTE"]);
+    for (var i = 0; i < nodes.length; i++) {
+        if (nodes[i].split("-")[0] === "Top/templateID") {
+            return node.getTextAttr(nodes[i], 1.0, "text");
+        }
+    }
+    return null;
+    }
+    returnNodeAttr"""
+
+    data = harmony.send({"function": func})["result"]
+
+    with open(LOG, "a") as f:
+        f.write(f"#################\n")
+        f.write(f"get_all_top_names : {harmony.get_all_top_names()}\n")
+        f.write(f"containers_names : {containers_names}\n")
+        f.write(f"scene_data : {scene_data}\n")
+        f.write(f"data : {data}\n")
+        
     # Update scene data if cleaned
     if cleaned_scene_data:
         harmony.set_scene_data(scene_data)

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -1,7 +1,6 @@
 import os
 from pathlib import Path
 import logging
-
 from qtpy import QtWidgets
 
 from ayon_core import style
@@ -11,6 +10,7 @@ from ayon_core.tools.utils.host_tools import (
 )
 
 import json
+
 
 import pyblish.api
 
@@ -51,11 +51,6 @@ from .workio import (
     file_extensions,
     work_root
 )
-
-log_path = r"C:\Users\normaal\Documents\YuanDev\AYON-Development-Workbench\ayon-harmony\LOG.txt"
-
-log = logging.getLogger("ayon_harmony")
-
 PLUGINS_DIR = os.path.join(HARMONY_ADDON_ROOT, "plugins")
 PUBLISH_PATH = os.path.join(PLUGINS_DIR, "publish")
 LOAD_PATH = os.path.join(PLUGINS_DIR, "load")
@@ -103,8 +98,6 @@ class HarmonyHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         return file_extensions()
 
     def get_containers(self):
-        with open(log_path, "a") as f:
-            f.write("@@@@@@@ get_containers\n")
         return ls()
 
     def get_context_data(self):
@@ -323,11 +316,10 @@ def is_container_data(data: dict) -> bool:
 
 
 def read_metadata_from_backdrops() -> dict:
-    """Read metadata of templates from backdrop description fields.
-    
-    Looks for backdrops containing '<AYON_METADATA/>' marker in their
-    description text and parses the JSON metadata that follows.
-    
+    """Read metadata of templates from backdrop text fields.
+
+    Looks for backdrops containing marker in their description text and parses the JSON metadata that follows.
+
     Returns:
         dict: Dictionary with metadata.
     """
@@ -346,19 +338,27 @@ def read_metadata_from_backdrops() -> dict:
         return results;
     }
     readBackdropMetadata"""
-    
+
     metadata_list = harmony.send({"function": func})["result"]
     metadata_dict = {}
     for entry in metadata_list:
         metadata_dict |= json.loads(entry)
     return metadata_dict
 
+
 def ensure_metadata_in_backdrop(backdrop_name: str, metadata: dict):
+    """Ensure AYON metadata is stored in a backdrop's text field.
+
+    Looks for a backdrop matching the given name and checks if the marker is already present in its description.
+    If not, appends the marker and the serialized metadata as JSON, separated by lines to keep it hidden from animators.
+
+    Args:
+        backdrop_name (str): Name of the backdrop to write metadata into.
+        metadata (dict): Metadata to store in the backdrop.
+    """
     metadata_json = json.dumps(metadata).replace('"', '\\"')
     separator = "\\n" * 100
-    harmony.send(
-        {
-            "script": f"""
+    harmony.send({"script": f"""
     var backdrops = Backdrop.backdrops("Top");
     for (var i = 0; i < backdrops.length; i++) {{
         if (backdrops[i].title.text === "{backdrop_name}") {{
@@ -366,15 +366,13 @@ def ensure_metadata_in_backdrop(backdrop_name: str, metadata: dict):
             var marker = "<AYON_METADATA/>";
             var markerIndex = currentText.indexOf(marker);
             if (markerIndex === -1) {{
-                backdrops[i].description.text = currentText + marker + "\\n" + "{metadata_json}";
+                backdrops[i].description.text = currentText + "{separator}" + marker + "\\n" + "{metadata_json}";
                 Backdrop.setBackdrops("Top", backdrops);
                 MessageLog.trace("Metadata ensured in backdrop: " + backdrops[i].title.text);
             }}
         }}
     }}
-    """
-        }
-    )
+    """})
 
 
 def ls():
@@ -386,11 +384,7 @@ def ls():
         dict: container
     """
     scene_data = harmony.get_scene_data() or dict()
-    with open(log_path, "a") as f:
-        f.write(f"@@@@@@@ scene_data {scene_data}\n")
-    containers_names = (
-        harmony.get_all_top_names() | harmony.get_palettes_paths()
-    )
+    containers_names = harmony.get_all_top_names() | harmony.get_palettes_paths()
 
     updated_scene_data = False
     for entity_name, entity_data in scene_data.copy().items():
@@ -401,29 +395,28 @@ def ls():
         if entity_name not in containers_names:
             del scene_data[entity_name]
             updated_scene_data = True
-            continue
-
-        if not entity_data.get("objectName"):  # backward compatibility
-            entity_data["objectName"] = entity_data["name"]
-        yield entity_data
-
-    METADATA_EXCLUDED_KEYS = {"nodes", "objectName"}
 
     for entity_name, entity_data in scene_data.items():
         if is_container_data(entity_data):
-            clean_data = {k: v for k, v in entity_data.items() 
-                        if k not in METADATA_EXCLUDED_KEYS}
+            clean_data = {
+                k: v for k, v in entity_data.items()
+            }
             ensure_metadata_in_backdrop(entity_name, {entity_name: clean_data})
-        
-    metadata = read_metadata_from_backdrops()
-    for entity_name, entity_data in metadata.items():
+
+    for entity_name, entity_data in read_metadata_from_backdrops().items():
         if entity_name not in scene_data:
             updated_scene_data = True
             scene_data[entity_name] = entity_data
-        yield entity_data
 
-    with open(log_path, "a") as f:
-        f.write(f"@@@@@@@ updated_scene_data {updated_scene_data}\n")
+        # Single yield point
+    for entity_name, entity_data in scene_data.items():
+        if not is_container_data(entity_data):
+            continue
+        if entity_name not in containers_names:
+            continue
+        if not entity_data.get("objectName"):
+            entity_data["objectName"] = entity_data["name"]
+        yield entity_data
 
     if updated_scene_data:
         harmony.set_scene_data(scene_data)

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -315,7 +315,7 @@ def is_container_data(data: dict) -> bool:
     return data and data.get("id") in {AYON_CONTAINER_ID, AVALON_CONTAINER_ID}
 
 
-def ls():
+def ls(): 
     """Yields containers from Harmony scene.
 
     Clean up scene data from orphaned containers.

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -247,7 +247,7 @@ def get_metadata_from_note()-> dict:
     """Get metadata of templates from note nodes and return them as a dictionary.
 
     Returns:
-        dict[str, dict]: Dictionary with metadata.
+        dict: Dictionary with metadata.
     """
 
     func = """function returnNodeAttr() {

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -243,12 +243,11 @@ def is_container_data(data: dict) -> bool:
     return data and data.get("id") in {AYON_CONTAINER_ID, AVALON_CONTAINER_ID}
 
 
-def read_note_nodes() -> dict:
-    """Read all note nodes containing metadata in the scene and return text as a dictionary.
+def get_metadata_from_note()-> dict:
+    """Get metadata of templates from note nodes and return them as a dictionary.
 
     Returns:
-        dict: Dictionary with metadata.
-
+        dict[str, dict]: Dictionary with metadata.
     """
 
     func = """function returnNodeAttr() {
@@ -302,12 +301,13 @@ def ls():
             entity_data["objectName"] = entity_data["name"]
         yield entity_data
 
-    metadata = read_note_nodes()
+    metadata = get_metadata_from_note()
 
     for entity_name, entity_data in metadata.items():
         if entity_name not in scene_data:
             updated_scene_data = True
             scene_data[entity_name] = entity_data
+        yield entity_data
 
     if updated_scene_data:
         harmony.set_scene_data(scene_data)

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -242,14 +242,15 @@ def is_container_data(data: dict) -> bool:
     """Return whether data is container data."""
     return data and data.get("id") in {AYON_CONTAINER_ID, AVALON_CONTAINER_ID}
 
-def read_note_nodes():
+
+def read_note_nodes() -> dict:
     """Read all note nodes containing metadata in the scene and return text as a dictionary.
 
     Returns:
         dict: Dictionary with metadata.
 
     """
-    
+
     func = """function returnNodeAttr() {
     var nodes = node.getNodes(["NOTE"]);
     var results = [];

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -242,11 +242,41 @@ def is_container_data(data: dict) -> bool:
     """Return whether data is container data."""
     return data and data.get("id") in {AYON_CONTAINER_ID, AVALON_CONTAINER_ID}
 
+def read_note_nodes():
+    """Read all note nodes containing metadata in the scene and return text as a dictionary.
+
+    Returns:
+        dict: Dictionary with metadata.
+
+    """
+    
+    func = """function returnNodeAttr() {
+    var nodes = node.getNodes(["NOTE"]);
+    var results = [];
+    for (var i = 0; i < nodes.length; i++) {
+        if (nodes[i].split("-")[0] === "Top/templateID") {
+            var data = node.getTextAttr(nodes[i], 1.0, "text");
+            results.push(data);
+            }
+        }
+        return results;
+    }
+    returnNodeAttr"""
+
+    metadata_list = harmony.send({"function": func})["result"]
+
+    metadata_dict = {}
+    for note in metadata_list:
+        metadata_dict |= ast.literal_eval(note)
+
+    return metadata_dict
+
 
 def ls():
     """Yields containers from Harmony scene.
 
     Clean up scene data from orphaned containers.
+    look for note nodes with metadata and add them to scene data if not registered.
 
     Yields:
         dict: container
@@ -271,27 +301,9 @@ def ls():
             entity_data["objectName"] = entity_data["name"]
         yield entity_data
 
-    # to look for new containers pasted to the scene
-    func = """function returnNodeAttr() {
-    var nodes = node.getNodes(["NOTE"]);
-    var results = [];
-    for (var i = 0; i < nodes.length; i++) {
-        if (nodes[i].split("-")[0] === "Top/templateID") {
-            var data = node.getTextAttr(nodes[i], 1.0, "text");
-            results.push(data);
-            }
-        }
-        return results;
-    }
-    returnNodeAttr"""
+    metadata = read_note_nodes()
 
-    note_node_texts = harmony.send({"function": func})["result"]
-
-    note_dict = {}
-    for note in note_node_texts:
-        note_dict |= ast.literal_eval(note)
-
-    for entity_name, entity_data in note_dict.items():
+    for entity_name, entity_data in metadata.items():
         if entity_name not in scene_data:
             updated_scene_data = True
             scene_data[entity_name] = entity_data

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -285,10 +285,10 @@ def ls():
     }
     returnNodeAttr"""
 
-    note_node_text = harmony.send({"function": func})["result"]
+    note_node_texts = harmony.send({"function": func})["result"]
 
     note_dict = {}
-    for note in note_node_text:
+    for note in note_node_texts:
         note_dict |= ast.literal_eval(note)
 
     for entity_name, entity_data in note_dict.items():

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -243,8 +243,8 @@ def is_container_data(data: dict) -> bool:
     return data and data.get("id") in {AYON_CONTAINER_ID, AVALON_CONTAINER_ID}
 
 
-def get_metadata_from_note()-> dict:
-    """Get metadata of templates from note nodes and return them as a dictionary.
+def read_metadata_from_notes() -> dict:
+    """Read metadata of templates from note nodes and return them as a dictionary.
 
     Returns:
         dict: Dictionary with metadata.
@@ -254,7 +254,7 @@ def get_metadata_from_note()-> dict:
     var nodes = node.getNodes(["NOTE"]);
     var results = [];
     for (var i = 0; i < nodes.length; i++) {
-        if (nodes[i].split("-")[0] === "Top/templateID") {
+        if (nodes[i].indexOf("Top/ayon-metadata") !== -1) {
             var data = node.getTextAttr(nodes[i], 1.0, "text");
             results.push(data);
             }
@@ -301,7 +301,7 @@ def ls():
             entity_data["objectName"] = entity_data["name"]
         yield entity_data
 
-    metadata = get_metadata_from_note()
+    metadata = read_metadata_from_notes()
 
     for entity_name, entity_data in metadata.items():
         if entity_name not in scene_data:

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -276,7 +276,8 @@ def ls():
     """Yields containers from Harmony scene.
 
     Clean up scene data from orphaned containers.
-    look for note nodes with metadata and add them to scene data if not registered.
+
+    Look for note nodes with metadata and add them to scene data if not registered.
 
     Yields:
         dict: container

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -254,7 +254,7 @@ def read_metadata_from_notes() -> dict:
     var nodes = node.getNodes(["NOTE"]);
     var results = [];
     for (var i = 0; i < nodes.length; i++) {
-        if (nodes[i].indexOf("Top/ayon-metadata") !== -1) {
+        if (nodes[i].indexOf("ayon-metadata") !== -1) {
             var data = node.getTextAttr(nodes[i], 1.0, "text");
             results.push(data);
             }

--- a/client/ayon_harmony/plugins/load/load_template.py
+++ b/client/ayon_harmony/plugins/load/load_template.py
@@ -87,15 +87,15 @@ class TemplateLoader(harmony.BackdropBaseLoader):
             context,
             self_name
         )
-    
+
     def metadata_to_note(self, backdrop_name, data, context):
         """Create a note node and write metadata to that node.
 
-        Args: 
+        Args:
             backdrop_name (str): Name of the backdrop to which the note will be attached.
             data (dict): Metadata to be stored in the note.
             context (:class:`pyblish.api.Context`): The context containing representation information.
-        
+
         """
 
         harmony.send(
@@ -115,5 +115,3 @@ class TemplateLoader(harmony.BackdropBaseLoader):
         """
             }
         )
-
-

--- a/client/ayon_harmony/plugins/load/load_template.py
+++ b/client/ayon_harmony/plugins/load/load_template.py
@@ -24,6 +24,8 @@ class TemplateLoader(harmony.BackdropBaseLoader):
     def load(self, context, name=None, namespace=None, data=None):
         """Plugin entry point.
 
+        Write metadata to note node for better tracking.
+
         Args:
             context (:class:`pyblish.api.Context`): Context.
             name (str, optional): Container name.
@@ -72,7 +74,30 @@ class TemplateLoader(harmony.BackdropBaseLoader):
             }
         }
 
-        # to allow the backdrop to be pasted to another scene, we store the metadata in a note node
+        self.metadata_to_note(backdrop_name, data, context)
+
+        # Cleanup the temp directory
+        shutil.rmtree(temp_dir)
+
+        # We must validate the group_node
+        return harmony.containerise(
+            backdrop_name,
+            namespace,
+            backdrop_name,
+            context,
+            self_name
+        )
+    
+    def metadata_to_note(self, backdrop_name, data, context):
+        """Create a note node and write metadata to that node.
+
+        Args: 
+            backdrop_name (str): Name of the backdrop to which the note will be attached.
+            data (dict): Metadata to be stored in the note.
+            context (:class:`pyblish.api.Context`): The context containing representation information.
+        
+        """
+
         harmony.send(
             {
                 "script": f"""
@@ -91,14 +116,4 @@ class TemplateLoader(harmony.BackdropBaseLoader):
             }
         )
 
-        # Cleanup the temp directory
-        shutil.rmtree(temp_dir)
 
-        # We must validate the group_node
-        return harmony.containerise(
-            backdrop_name,
-            namespace,
-            backdrop_name,
-            context,
-            self_name
-        )

--- a/client/ayon_harmony/plugins/load/load_template.py
+++ b/client/ayon_harmony/plugins/load/load_template.py
@@ -7,6 +7,14 @@ import shutil
 
 import ayon_harmony.api as harmony
 
+from ayon_core.pipeline import (
+    register_loader_plugin_path,
+    register_creator_plugin_path,
+    deregister_loader_plugin_path,
+    deregister_creator_plugin_path,
+    AVALON_CONTAINER_ID,
+    AYON_CONTAINER_ID,
+)
 
 class TemplateLoader(harmony.BackdropBaseLoader):
     """Load Harmony template as Backdrop container."""
@@ -51,14 +59,49 @@ class TemplateLoader(harmony.BackdropBaseLoader):
             }
         )["result"]
 
-        # Cleanup the temp directory
-        shutil.rmtree(temp_dir)
-
-        # We must validate the group_node
-        return harmony.containerise(
+        containerized = harmony.containerise(
             backdrop_name,
             namespace,
             backdrop_name,
             context,
             self_name
         )
+
+        data = {
+        "schema": "openpype:container-2.0",
+        "id": AYON_CONTAINER_ID,
+        "name": backdrop_name,
+        "namespace": namespace,
+        "loader": str(self_name),
+        "representation": context["representation"]["id"]
+        }
+
+        harmony.send({"script": f"""
+        var backdrops = Backdrop.backdrops("Top");
+        var targetBackdrop = null;
+        for (var i = 0; i < backdrops.length; i++) {{
+            if (backdrops[i].title.text === "{backdrop_name}") {{
+                targetBackdrop = backdrops[i];
+                break;
+            }}
+        }}
+
+        if (targetBackdrop) {{
+            var x = targetBackdrop.position.x + 50;
+            var y = targetBackdrop.position.y + 50;
+            
+            var noteName = "templateID-{context["representation"]["id"]}";
+            var result = node.add("Top", noteName, "NOTE", x, y, 0);
+            node.setTextAttr(result, "text", frame.current(), "{data}");
+            MessageLog.trace("NOTE créé : " + result + " à x:" + x + " y:" + y);
+        }} 
+        else {{
+            MessageLog.trace("Backdrop introuvable !");
+        }}
+        """})
+
+        # Cleanup the temp directory
+        shutil.rmtree(temp_dir)
+
+        # We must validate the group_node
+        return containerized

--- a/client/ayon_harmony/plugins/load/load_template.py
+++ b/client/ayon_harmony/plugins/load/load_template.py
@@ -24,7 +24,7 @@ class TemplateLoader(harmony.BackdropBaseLoader):
     def load(self, context, name=None, namespace=None, data=None):
         """Plugin entry point.
 
-        Write metadata to note node for better tracking.
+        Write metadata to note node in the backdrop for better tracking of the container and its metadata.
 
         Args:
             context (:class:`pyblish.api.Context`): Context.
@@ -63,7 +63,7 @@ class TemplateLoader(harmony.BackdropBaseLoader):
             }
         )["result"]
 
-        data = {
+        metadata = {
             backdrop_name: {
                 "schema": "openpype:container-2.0",
                 "id": AYON_CONTAINER_ID,
@@ -74,7 +74,7 @@ class TemplateLoader(harmony.BackdropBaseLoader):
             }
         }
 
-        self.metadata_to_note(backdrop_name, data, context)
+        self.write_metadata_to_note(backdrop_name, metadata, context)
 
         # Cleanup the temp directory
         shutil.rmtree(temp_dir)
@@ -88,14 +88,13 @@ class TemplateLoader(harmony.BackdropBaseLoader):
             self_name
         )
 
-    def metadata_to_note(self, backdrop_name, data, context):
+    def write_metadata_to_note(self, backdrop_name : str, metadata : dict, context):
         """Create a note node and write metadata to that node.
 
         Args:
             backdrop_name (str): Name of the backdrop to which the note will be attached.
-            data (dict): Metadata to be stored in the note.
+            metadata (dict): Metadata to be stored in the note.
             context (:class:`pyblish.api.Context`): The context containing representation information.
-
         """
 
         harmony.send(
@@ -109,7 +108,7 @@ class TemplateLoader(harmony.BackdropBaseLoader):
                 
                 var noteName = "templateID-{context["representation"]["id"]}";
                 var result = node.add("Top", noteName, "NOTE", x, y, 0);
-                node.setTextAttr(result, "text", 1.0, "{data}");
+                node.setTextAttr(result, "text", 1.0, "{metadata}");
                 MessageLog.trace("Note created : " + result + " at x:" + x + " y:" + y);
         }}
         """

--- a/client/ayon_harmony/plugins/load/load_template.py
+++ b/client/ayon_harmony/plugins/load/load_template.py
@@ -10,7 +10,10 @@ import ayon_harmony.api as harmony
 from ayon_core.pipeline import (
     AYON_CONTAINER_ID,
 )
+import os
 
+log_path = os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "LOG.txt")
+log_path = os.path.normpath(log_path)
 class TemplateLoader(harmony.BackdropBaseLoader):
     """Load Harmony template as Backdrop container."""
 
@@ -73,7 +76,7 @@ class TemplateLoader(harmony.BackdropBaseLoader):
             }
         }
 
-        self.write_metadata_to_note(backdrop_name, metadata)
+        harmony.ensure_metadata_in_backdrop(backdrop_name, metadata)
 
         # Cleanup the temp directory
         shutil.rmtree(temp_dir)
@@ -85,29 +88,4 @@ class TemplateLoader(harmony.BackdropBaseLoader):
             backdrop_name,
             context,
             self_name
-        )
-
-    def write_metadata_to_note(self, backdrop_name: str, metadata: dict):
-        """Create a note node and write metadata to that node.
-
-        Args:
-            backdrop_name (str): Name of the backdrop to which the note will be attached.
-            metadata (dict): Metadata to be stored in the note.
-        """
-
-        harmony.send(
-            {
-                "script": f"""
-        var backdrops = Backdrop.backdrops("Top");
-        for (var i = 0; i < backdrops.length; i++) 
-            if (backdrops[i].title.text === "{backdrop_name}") {{
-                var x = backdrops[i].position.x + 50;
-                var y = backdrops[i].position.y + 50;
-                
-                var result = node.add("Top", "ayon-metadata", "NOTE", x, y, 0);
-                node.setTextAttr(result, "text", 1.0, "{metadata}");
-                MessageLog.trace("Note created : " + result + " at x:" + x + " y:" + y);
-        }}
-        """
-            }
         )

--- a/client/ayon_harmony/plugins/load/load_template.py
+++ b/client/ayon_harmony/plugins/load/load_template.py
@@ -8,11 +8,6 @@ import shutil
 import ayon_harmony.api as harmony
 
 from ayon_core.pipeline import (
-    register_loader_plugin_path,
-    register_creator_plugin_path,
-    deregister_loader_plugin_path,
-    deregister_creator_plugin_path,
-    AVALON_CONTAINER_ID,
     AYON_CONTAINER_ID,
 )
 
@@ -66,49 +61,47 @@ class TemplateLoader(harmony.BackdropBaseLoader):
             }
         )["result"]
 
-        containerized = harmony.containerise(
+        data = {
+            backdrop_name: {
+                "schema": "openpype:container-2.0",
+                "id": AYON_CONTAINER_ID,
+                "name": backdrop_name,
+                "namespace": namespace,
+                "loader": str(self_name),
+                "representation": context["representation"]["id"],
+            }
+        }
+
+        # to allow the backdrop to be pasted to another scene, we store the metadata in a note node
+        harmony.send(
+            {
+                "script": f"""
+        var backdrops = Backdrop.backdrops("Top");
+        for (var i = 0; i < backdrops.length; i++) 
+            if (backdrops[i].title.text === "{backdrop_name}") {{
+                var x = backdrops[i].position.x + 50;
+                var y = backdrops[i].position.y + 50;
+                
+                var noteName = "templateID-{context["representation"]["id"]}";
+                var result = node.add("Top", noteName, "NOTE", x, y, 0);
+                node.setTextAttr(result, "text", frame.current(), "{data}");
+                MessageLog.trace("note created : " + result + " at x:" + x + " y:" + y);
+        }}
+        else {{
+            MessageLog.trace("Backdrop not found !");
+        }}
+        """
+            }
+        )
+
+        # Cleanup the temp directory
+        shutil.rmtree(temp_dir)
+
+        # We must validate the group_node
+        return harmony.containerise(
             backdrop_name,
             namespace,
             backdrop_name,
             context,
             self_name
         )
-
-        data = {
-        "schema": "openpype:container-2.0",
-        "id": AYON_CONTAINER_ID,
-        "name": backdrop_name,
-        "namespace": namespace,
-        "loader": str(self_name),
-        "representation": context["representation"]["id"]
-        }
-
-        harmony.send({"script": f"""
-        var backdrops = Backdrop.backdrops("Top");
-        var targetBackdrop = null;
-        for (var i = 0; i < backdrops.length; i++) {{
-            if (backdrops[i].title.text === "{backdrop_name}") {{
-                targetBackdrop = backdrops[i];
-                break;
-            }}
-        }}
-
-        if (targetBackdrop) {{
-            var x = targetBackdrop.position.x + 50;
-            var y = targetBackdrop.position.y + 50;
-            
-            var noteName = "templateID-{context["representation"]["id"]}";
-            var result = node.add("Top", noteName, "NOTE", x, y, 0);
-            node.setTextAttr(result, "text", frame.current(), "{data}");
-            MessageLog.trace("NOTE créé : " + result + " à x:" + x + " y:" + y);
-        }} 
-        else {{
-            MessageLog.trace("Backdrop introuvable !");
-        }}
-        """})
-
-        # Cleanup the temp directory
-        shutil.rmtree(temp_dir)
-
-        # We must validate the group_node
-        return containerized

--- a/client/ayon_harmony/plugins/load/load_template.py
+++ b/client/ayon_harmony/plugins/load/load_template.py
@@ -85,10 +85,7 @@ class TemplateLoader(harmony.BackdropBaseLoader):
                 var noteName = "templateID-{context["representation"]["id"]}";
                 var result = node.add("Top", noteName, "NOTE", x, y, 0);
                 node.setTextAttr(result, "text", 1.0, "{data}");
-                MessageLog.trace("note created : " + result + " at x:" + x + " y:" + y);
-        }}
-        else {{
-            MessageLog.trace("Backdrop not found !");
+                MessageLog.trace("Note created : " + result + " at x:" + x + " y:" + y);
         }}
         """
             }

--- a/client/ayon_harmony/plugins/load/load_template.py
+++ b/client/ayon_harmony/plugins/load/load_template.py
@@ -84,7 +84,7 @@ class TemplateLoader(harmony.BackdropBaseLoader):
                 
                 var noteName = "templateID-{context["representation"]["id"]}";
                 var result = node.add("Top", noteName, "NOTE", x, y, 0);
-                node.setTextAttr(result, "text", frame.current(), "{data}");
+                node.setTextAttr(result, "text", 1.0, "{data}");
                 MessageLog.trace("note created : " + result + " at x:" + x + " y:" + y);
         }}
         else {{

--- a/client/ayon_harmony/plugins/load/load_template.py
+++ b/client/ayon_harmony/plugins/load/load_template.py
@@ -77,7 +77,7 @@ class TemplateLoader(harmony.BackdropBaseLoader):
                 
                 var noteName = "templateID-{context["representation"]["id"]}";
                 var result = node.add("Top", noteName, "NOTE", x, y, 0);
-                node.setTextAttr(result, "text", frame.current(), "{data}");
+                node.setTextAttr(result, "text", 1.0, "{data}");
                 MessageLog.trace("note created : " + result + " at x:" + x + " y:" + y);
         }}
         else {{

--- a/client/ayon_harmony/plugins/load/load_template.py
+++ b/client/ayon_harmony/plugins/load/load_template.py
@@ -8,11 +8,6 @@ import shutil
 import ayon_harmony.api as harmony
 
 from ayon_core.pipeline import (
-    register_loader_plugin_path,
-    register_creator_plugin_path,
-    deregister_loader_plugin_path,
-    deregister_creator_plugin_path,
-    AVALON_CONTAINER_ID,
     AYON_CONTAINER_ID,
 )
 
@@ -59,49 +54,47 @@ class TemplateLoader(harmony.BackdropBaseLoader):
             }
         )["result"]
 
-        containerized = harmony.containerise(
+        data = {
+            backdrop_name: {
+                "schema": "openpype:container-2.0",
+                "id": AYON_CONTAINER_ID,
+                "name": backdrop_name,
+                "namespace": namespace,
+                "loader": str(self_name),
+                "representation": context["representation"]["id"],
+            }
+        }
+
+        # to allow the backdrop to be pasted to another scene, we store the metadata in a note node
+        harmony.send(
+            {
+                "script": f"""
+        var backdrops = Backdrop.backdrops("Top");
+        for (var i = 0; i < backdrops.length; i++) 
+            if (backdrops[i].title.text === "{backdrop_name}") {{
+                var x = backdrops[i].position.x + 50;
+                var y = backdrops[i].position.y + 50;
+                
+                var noteName = "templateID-{context["representation"]["id"]}";
+                var result = node.add("Top", noteName, "NOTE", x, y, 0);
+                node.setTextAttr(result, "text", frame.current(), "{data}");
+                MessageLog.trace("note created : " + result + " at x:" + x + " y:" + y);
+        }}
+        else {{
+            MessageLog.trace("Backdrop not found !");
+        }}
+        """
+            }
+        )
+
+        # Cleanup the temp directory
+        shutil.rmtree(temp_dir)
+
+        # We must validate the group_node
+        return harmony.containerise(
             backdrop_name,
             namespace,
             backdrop_name,
             context,
             self_name
         )
-
-        data = {
-        "schema": "openpype:container-2.0",
-        "id": AYON_CONTAINER_ID,
-        "name": backdrop_name,
-        "namespace": namespace,
-        "loader": str(self_name),
-        "representation": context["representation"]["id"]
-        }
-
-        harmony.send({"script": f"""
-        var backdrops = Backdrop.backdrops("Top");
-        var targetBackdrop = null;
-        for (var i = 0; i < backdrops.length; i++) {{
-            if (backdrops[i].title.text === "{backdrop_name}") {{
-                targetBackdrop = backdrops[i];
-                break;
-            }}
-        }}
-
-        if (targetBackdrop) {{
-            var x = targetBackdrop.position.x + 50;
-            var y = targetBackdrop.position.y + 50;
-            
-            var noteName = "templateID-{context["representation"]["id"]}";
-            var result = node.add("Top", noteName, "NOTE", x, y, 0);
-            node.setTextAttr(result, "text", frame.current(), "{data}");
-            MessageLog.trace("NOTE créé : " + result + " à x:" + x + " y:" + y);
-        }} 
-        else {{
-            MessageLog.trace("Backdrop introuvable !");
-        }}
-        """})
-
-        # Cleanup the temp directory
-        shutil.rmtree(temp_dir)
-
-        # We must validate the group_node
-        return containerized

--- a/client/ayon_harmony/plugins/load/load_template.py
+++ b/client/ayon_harmony/plugins/load/load_template.py
@@ -73,7 +73,7 @@ class TemplateLoader(harmony.BackdropBaseLoader):
             }
         }
 
-        self.write_metadata_to_note(backdrop_name, metadata, context)
+        self.write_metadata_to_note(backdrop_name, metadata)
 
         # Cleanup the temp directory
         shutil.rmtree(temp_dir)
@@ -87,13 +87,12 @@ class TemplateLoader(harmony.BackdropBaseLoader):
             self_name
         )
 
-    def write_metadata_to_note(self, backdrop_name : str, metadata : dict, context):
+    def write_metadata_to_note(self, backdrop_name: str, metadata: dict):
         """Create a note node and write metadata to that node.
 
         Args:
             backdrop_name (str): Name of the backdrop to which the note will be attached.
             metadata (dict): Metadata to be stored in the note.
-            context (:class:`pyblish.api.Context`): The context containing representation information.
         """
 
         harmony.send(
@@ -105,8 +104,7 @@ class TemplateLoader(harmony.BackdropBaseLoader):
                 var x = backdrops[i].position.x + 50;
                 var y = backdrops[i].position.y + 50;
                 
-                var noteName = "templateID-{context["representation"]["id"]}";
-                var result = node.add("Top", noteName, "NOTE", x, y, 0);
+                var result = node.add("Top", "ayon-metadata", "NOTE", x, y, 0);
                 node.setTextAttr(result, "text", 1.0, "{metadata}");
                 MessageLog.trace("Note created : " + result + " at x:" + x + " y:" + y);
         }}

--- a/client/ayon_harmony/plugins/load/load_template.py
+++ b/client/ayon_harmony/plugins/load/load_template.py
@@ -31,7 +31,6 @@ class TemplateLoader(harmony.BackdropBaseLoader):
             name (str, optional): Container name.
             namespace (str, optional): Container namespace.
             data (dict, optional): Additional data passed into loader.
-
         """
         # Load template.
         self_name = self.__class__.__name__

--- a/client/ayon_harmony/plugins/load/load_template.py
+++ b/client/ayon_harmony/plugins/load/load_template.py
@@ -7,6 +7,14 @@ import shutil
 
 import ayon_harmony.api as harmony
 
+from ayon_core.pipeline import (
+    register_loader_plugin_path,
+    register_creator_plugin_path,
+    deregister_loader_plugin_path,
+    deregister_creator_plugin_path,
+    AVALON_CONTAINER_ID,
+    AYON_CONTAINER_ID,
+)
 
 class TemplateLoader(harmony.BackdropBaseLoader):
     """Load Harmony template as Backdrop container."""
@@ -58,14 +66,49 @@ class TemplateLoader(harmony.BackdropBaseLoader):
             }
         )["result"]
 
-        # Cleanup the temp directory
-        shutil.rmtree(temp_dir)
-
-        # We must validate the group_node
-        return harmony.containerise(
+        containerized = harmony.containerise(
             backdrop_name,
             namespace,
             backdrop_name,
             context,
             self_name
         )
+
+        data = {
+        "schema": "openpype:container-2.0",
+        "id": AYON_CONTAINER_ID,
+        "name": backdrop_name,
+        "namespace": namespace,
+        "loader": str(self_name),
+        "representation": context["representation"]["id"]
+        }
+
+        harmony.send({"script": f"""
+        var backdrops = Backdrop.backdrops("Top");
+        var targetBackdrop = null;
+        for (var i = 0; i < backdrops.length; i++) {{
+            if (backdrops[i].title.text === "{backdrop_name}") {{
+                targetBackdrop = backdrops[i];
+                break;
+            }}
+        }}
+
+        if (targetBackdrop) {{
+            var x = targetBackdrop.position.x + 50;
+            var y = targetBackdrop.position.y + 50;
+            
+            var noteName = "templateID-{context["representation"]["id"]}";
+            var result = node.add("Top", noteName, "NOTE", x, y, 0);
+            node.setTextAttr(result, "text", frame.current(), "{data}");
+            MessageLog.trace("NOTE créé : " + result + " à x:" + x + " y:" + y);
+        }} 
+        else {{
+            MessageLog.trace("Backdrop introuvable !");
+        }}
+        """})
+
+        # Cleanup the temp directory
+        shutil.rmtree(temp_dir)
+
+        # We must validate the group_node
+        return containerized

--- a/client/ayon_harmony/plugins/load/load_template.py
+++ b/client/ayon_harmony/plugins/load/load_template.py
@@ -78,10 +78,7 @@ class TemplateLoader(harmony.BackdropBaseLoader):
                 var noteName = "templateID-{context["representation"]["id"]}";
                 var result = node.add("Top", noteName, "NOTE", x, y, 0);
                 node.setTextAttr(result, "text", 1.0, "{data}");
-                MessageLog.trace("note created : " + result + " at x:" + x + " y:" + y);
-        }}
-        else {{
-            MessageLog.trace("Backdrop not found !");
+                MessageLog.trace("Note created : " + result + " at x:" + x + " y:" + y);
         }}
         """
             }

--- a/client/ayon_harmony/plugins/load/load_template.py
+++ b/client/ayon_harmony/plugins/load/load_template.py
@@ -80,15 +80,15 @@ class TemplateLoader(harmony.BackdropBaseLoader):
             context,
             self_name
         )
-    
+
     def metadata_to_note(self, backdrop_name, data, context):
         """Create a note node and write metadata to that node.
 
-        Args: 
+        Args:
             backdrop_name (str): Name of the backdrop to which the note will be attached.
             data (dict): Metadata to be stored in the note.
             context (:class:`pyblish.api.Context`): The context containing representation information.
-        
+
         """
 
         harmony.send(
@@ -108,5 +108,3 @@ class TemplateLoader(harmony.BackdropBaseLoader):
         """
             }
         )
-
-

--- a/client/ayon_harmony/plugins/load/load_template.py
+++ b/client/ayon_harmony/plugins/load/load_template.py
@@ -29,7 +29,6 @@ class TemplateLoader(harmony.BackdropBaseLoader):
             name (str, optional): Container name.
             namespace (str, optional): Container namespace.
             data (dict, optional): Additional data passed into loader.
-
         """
         # Load template.
         self_name = self.__class__.__name__

--- a/client/ayon_harmony/plugins/load/load_template.py
+++ b/client/ayon_harmony/plugins/load/load_template.py
@@ -66,7 +66,7 @@ class TemplateLoader(harmony.BackdropBaseLoader):
             }
         }
 
-        self.write_metadata_to_note(backdrop_name, metadata, context)
+        self.write_metadata_to_note(backdrop_name, metadata)
 
         # Cleanup the temp directory
         shutil.rmtree(temp_dir)
@@ -80,13 +80,12 @@ class TemplateLoader(harmony.BackdropBaseLoader):
             self_name
         )
 
-    def write_metadata_to_note(self, backdrop_name : str, metadata : dict, context):
+    def write_metadata_to_note(self, backdrop_name: str, metadata: dict):
         """Create a note node and write metadata to that node.
 
         Args:
             backdrop_name (str): Name of the backdrop to which the note will be attached.
             metadata (dict): Metadata to be stored in the note.
-            context (:class:`pyblish.api.Context`): The context containing representation information.
         """
 
         harmony.send(
@@ -98,8 +97,7 @@ class TemplateLoader(harmony.BackdropBaseLoader):
                 var x = backdrops[i].position.x + 50;
                 var y = backdrops[i].position.y + 50;
                 
-                var noteName = "templateID-{context["representation"]["id"]}";
-                var result = node.add("Top", noteName, "NOTE", x, y, 0);
+                var result = node.add("Top", "ayon-metadata", "NOTE", x, y, 0);
                 node.setTextAttr(result, "text", 1.0, "{metadata}");
                 MessageLog.trace("Note created : " + result + " at x:" + x + " y:" + y);
         }}

--- a/client/ayon_harmony/plugins/load/load_template.py
+++ b/client/ayon_harmony/plugins/load/load_template.py
@@ -22,7 +22,7 @@ class TemplateLoader(harmony.BackdropBaseLoader):
     def load(self, context, name=None, namespace=None, data=None):
         """Plugin entry point.
 
-        Write metadata to note node for better tracking.
+        Write metadata to note node in the backdrop for better tracking of the container and its metadata.
 
         Args:
             context (:class:`pyblish.api.Context`): Context.
@@ -56,7 +56,7 @@ class TemplateLoader(harmony.BackdropBaseLoader):
             }
         )["result"]
 
-        data = {
+        metadata = {
             backdrop_name: {
                 "schema": "openpype:container-2.0",
                 "id": AYON_CONTAINER_ID,
@@ -67,7 +67,7 @@ class TemplateLoader(harmony.BackdropBaseLoader):
             }
         }
 
-        self.metadata_to_note(backdrop_name, data, context)
+        self.write_metadata_to_note(backdrop_name, metadata, context)
 
         # Cleanup the temp directory
         shutil.rmtree(temp_dir)
@@ -81,14 +81,13 @@ class TemplateLoader(harmony.BackdropBaseLoader):
             self_name
         )
 
-    def metadata_to_note(self, backdrop_name, data, context):
+    def write_metadata_to_note(self, backdrop_name : str, metadata : dict, context):
         """Create a note node and write metadata to that node.
 
         Args:
             backdrop_name (str): Name of the backdrop to which the note will be attached.
-            data (dict): Metadata to be stored in the note.
+            metadata (dict): Metadata to be stored in the note.
             context (:class:`pyblish.api.Context`): The context containing representation information.
-
         """
 
         harmony.send(
@@ -102,7 +101,7 @@ class TemplateLoader(harmony.BackdropBaseLoader):
                 
                 var noteName = "templateID-{context["representation"]["id"]}";
                 var result = node.add("Top", noteName, "NOTE", x, y, 0);
-                node.setTextAttr(result, "text", 1.0, "{data}");
+                node.setTextAttr(result, "text", 1.0, "{metadata}");
                 MessageLog.trace("Note created : " + result + " at x:" + x + " y:" + y);
         }}
         """

--- a/client/ayon_harmony/plugins/load/load_template.py
+++ b/client/ayon_harmony/plugins/load/load_template.py
@@ -22,6 +22,8 @@ class TemplateLoader(harmony.BackdropBaseLoader):
     def load(self, context, name=None, namespace=None, data=None):
         """Plugin entry point.
 
+        Write metadata to note node for better tracking.
+
         Args:
             context (:class:`pyblish.api.Context`): Context.
             name (str, optional): Container name.
@@ -65,7 +67,30 @@ class TemplateLoader(harmony.BackdropBaseLoader):
             }
         }
 
-        # to allow the backdrop to be pasted to another scene, we store the metadata in a note node
+        self.metadata_to_note(backdrop_name, data, context)
+
+        # Cleanup the temp directory
+        shutil.rmtree(temp_dir)
+
+        # We must validate the group_node
+        return harmony.containerise(
+            backdrop_name,
+            namespace,
+            backdrop_name,
+            context,
+            self_name
+        )
+    
+    def metadata_to_note(self, backdrop_name, data, context):
+        """Create a note node and write metadata to that node.
+
+        Args: 
+            backdrop_name (str): Name of the backdrop to which the note will be attached.
+            data (dict): Metadata to be stored in the note.
+            context (:class:`pyblish.api.Context`): The context containing representation information.
+        
+        """
+
         harmony.send(
             {
                 "script": f"""
@@ -84,14 +109,4 @@ class TemplateLoader(harmony.BackdropBaseLoader):
             }
         )
 
-        # Cleanup the temp directory
-        shutil.rmtree(temp_dir)
 
-        # We must validate the group_node
-        return harmony.containerise(
-            backdrop_name,
-            namespace,
-            backdrop_name,
-            context,
-            self_name
-        )


### PR DESCRIPTION
## Description
Enables users of the Ayon Harmony addon to copy and paste templates between scenes, with those templates automatically tracked through the Scene Inventory (Manage button).

## Additional review information
The tracking of those templates between scenes is enabled by the writing of metadata in a note node in the first scene, and the reading of that node in the second scene. The node is created in the template backdrop when the template is loaded. The reading happens at the opening of the Scene Inventory (in the harmony scene that you pasted into).

## Testing
1. Load one or two templates into a scene.
2. Open another harmony scene.
3. Copy the templates into the second scene.
4. Click on `Manage` in the Ayon menu.