### PR TITLE
Fix Clean Up failure because of lock

### DIFF
--- a/client/ayon_harmony/plugins/publish/extract_workfile.py
+++ b/client/ayon_harmony/plugins/publish/extract_workfile.py
@@ -29,6 +29,7 @@ class ExtractWorkfile(publish.Extractor):
         shutil.copytree(src, filepath)
 
         # Prep representation.
+        prev_cwd = os.getcwd()
         os.chdir(staging_dir)
         shutil.make_archive(
             f"{instance.name}",
@@ -39,6 +40,7 @@ class ExtractWorkfile(publish.Extractor):
         with ZipFile(os.path.basename(f"{instance.name}.zip")) as zr:
             if zr.testzip() is not None:
                 raise Exception("File archive is corrupted.")
+        os.chdir(prev_cwd)
 
         representation = {
             "name": "tpl",


### PR DESCRIPTION
## Changelog Description
This solves an issue in `Clean Up` plugin which triggered:
```
PermissionError: [WinError 32] The process cannot access the file because it is being used
```

## Testing notes:
1. publish (`workfile`) in Harmony (on Windows)
2. `Clean Up` shouldn't fail
