### PR TITLE
Fix closing python process

### DIFF
--- a/client/ayon_harmony/api/lib.py
+++ b/client/ayon_harmony/api/lib.py
@@ -152,11 +152,10 @@ def main(*subprocess_args):
     loop_timer.start()
 
     res = app.exec_()
-    try:
-        sys.exit(res)
-    finally:
-        if ProcessContext.server:
-            ProcessContext.server.stop()
+    if ProcessContext.server:
+        ProcessContext.server.stop()
+
+    sys.exit(res)
 
 
 def setup_startup_scripts():

--- a/client/ayon_harmony/api/lib.py
+++ b/client/ayon_harmony/api/lib.py
@@ -53,6 +53,8 @@ class ProcessContext:
     port = None
     stdout_broker = None
     workfile_tool = None
+    loop_timer = None
+    qt_app = None
 
     @classmethod
     def execute_in_main_thread(cls, func_to_call_from_main_thread):
@@ -64,8 +66,14 @@ class ProcessContext:
             callback = cls.callback_queue.popleft()
             callback()
         if cls.process is not None and cls.process.poll() is not None:
-            log.info("Server is not running, closing")
+            log.info("Server has stopped, cleaning up")
             ProcessContext.stdout_broker.stop()
+            if cls.loop_timer is not None:
+                cls.loop_timer.stop()
+                cls.loop_timer = None
+            if cls.qt_app is not None:
+                cls.qt_app.quit()
+            cls.process = None
 
 
 def _on_application_close():
@@ -133,15 +141,22 @@ def main(*subprocess_args):
     ProcessContext.stdout_broker = StdOutBroker('harmony')
     ProcessContext.stdout_broker.start()
     register_event_callback("application.close", _on_application_close)
+    ProcessContext.qt_app = app
     launch(*subprocess_args)
 
     loop_timer = QtCore.QTimer()
     loop_timer.setInterval(20)
+    ProcessContext.loop_timer = loop_timer
 
     loop_timer.timeout.connect(ProcessContext.main_thread_listen)
     loop_timer.start()
 
-    sys.exit(app.exec_())
+    res = app.exec_()
+    try:
+        sys.exit(res)
+    finally:
+        if ProcessContext.server:
+            ProcessContext.server.stop()
 
 
 def setup_startup_scripts():


### PR DESCRIPTION
## Changelog Description
This solves an issue where Python process (and attached console window) wasn't closed properly.


## Testing notes:
1. open and close Harmony
2. check that `cmd` windows got closed
3. check AYON Process Monitor that Harmony process got closed
<img width="521" height="204" alt="image" src="https://github.com/user-attachments/assets/9dc803ae-b19a-454a-be73-1da4c770570b" />
