### PR TITLE
Fix: Unzip wrong recursive naming

### DIFF
--- a/client/ayon_harmony/api/lib.py
+++ b/client/ayon_harmony/api/lib.py
@@ -485,26 +485,28 @@ def unzip_scene_file(filepath: str, headless: bool = False) -> str:
                 else local_scene_dir_path
             )
             new_name = local_scene_dir_path.name
+            root_prefix = f"{main_name}/"
+
+            def _rename_top_level_file(name):
+                if "/" not in name and Path(name).stem == main_name:
+                    return f"{new_name}{Path(name).suffix}"
+                return name
 
             for zip_info in zip_ref.infolist():
-                # Only rename entries at the top level of the archive.
-                # Subdirectory contents are left untouched so that
-                # similarly-named paths inside the scene are preserved.
-                head, sep, tail = zip_info.filename.partition("/")
-                if sep:
-                    # Nested path: only rename when the first segment
-                    # is the archive's root directory.
-                    if head == main_name:
-                        zip_info.filename = f"{new_name}/{tail}"
-                elif Path(head).stem == main_name:
-                    # Top-level file named like `{main_name}.<ext>`.
-                    zip_info.filename = f"{new_name}{Path(head).suffix}"
+                if has_root_dir:
+                    # Root-dir archives are handled by applying the same
+                    # top-level file rename one level deeper and then
+                    # reattaching the renamed root directory prefix.
+                    relative_name = zip_info.filename[len(root_prefix):]
+                    relative_name = _rename_top_level_file(relative_name)
+                    zip_info.filename = f"{new_name}/{relative_name}"
+                else:
+                    zip_info.filename = _rename_top_level_file(
+                        zip_info.filename
+                    )
 
                 zip_ref.extract(zip_info, extract_root)
-
-                # Keep the first xstage file as the scene path
-                if not scene_path and zip_info.filename.endswith(".xstage"):
-                    scene_path = Path(extract_root).joinpath(zip_info.filename)
+        scene_path = next(local_scene_dir_path.glob("*.xstage"), None)
 
     if not scene_path:
         raise Exception("No xstage file was found.")

--- a/client/ayon_harmony/api/lib.py
+++ b/client/ayon_harmony/api/lib.py
@@ -463,25 +463,43 @@ def unzip_scene_file(filepath: str, headless: bool = False) -> str:
     if unzip:
         filepath = localize_file(filepath)
         with _ZipFile(filepath, "r") as zip_ref:
+            names = zip_ref.namelist()
             main_name = next(
                 Path(name).stem
-                for name in zip_ref.namelist()
+                for name in names
                 if name.endswith(".xstage")
             )
-            for zip_info in zip_ref.infolist():
-                # Replace the root name with the local scene directory name
-                zip_info.filename = zip_info.filename.replace(
-                    main_name, local_scene_dir_path.name
-                )
 
-                extract_root = (
-                    local_scene_dir_path.parent
-                    # Deal with zip files with root directory
-                    if zip_info.filename.startswith(
-                        f"{local_scene_dir_path.name}/"
-                    )
-                    else local_scene_dir_path
-                )
+            # Detect if the archive is wrapped in a single root directory
+            # named after `main_name`. When it is, we extract into the
+            # parent of the local scene dir so the (renamed) root dir
+            # becomes the local scene dir itself.
+            has_root_dir = all(
+                name == f"{main_name}/"
+                or name.startswith(f"{main_name}/")
+                for name in names
+            )
+            extract_root = (
+                local_scene_dir_path.parent
+                if has_root_dir
+                else local_scene_dir_path
+            )
+            new_name = local_scene_dir_path.name
+
+            for zip_info in zip_ref.infolist():
+                # Only rename entries at the top level of the archive.
+                # Subdirectory contents are left untouched so that
+                # similarly-named paths inside the scene are preserved.
+                head, sep, tail = zip_info.filename.partition("/")
+                if sep:
+                    # Nested path: only rename when the first segment
+                    # is the archive's root directory.
+                    if head == main_name:
+                        zip_info.filename = f"{new_name}/{tail}"
+                elif Path(head).stem == main_name:
+                    # Top-level file named like `{main_name}.<ext>`.
+                    zip_info.filename = f"{new_name}{Path(head).suffix}"
+
                 zip_ref.extract(zip_info, extract_root)
 
                 # Keep the first xstage file as the scene path


### PR DESCRIPTION
## Changelog Description
Fixing recursive renaming occuring during archive unzipping.

## Additional review information
In case a scene is published through the tray publisher, for example a character ingested in pipeline and supposed to be rigged, it may have a `char_name.xstage` and in `palette-library/` have files like `char_name.plt`. With the auto rename of all, these palette files will be renamed, which will break scene at opening, because it wont find these expected library files any more. So, only first level files (`.aux`, `.xstage`) or the root directory if existing must be renamed, all items living in subdirectories must have their names preserved.

## Testing notes:
1. Create a `.tpl` with palettes as a workfile for a task
2. Publish it through tray publisher
3. Open the task workfile using the launcher.
