### PR TITLE
Fix: Load PSD broken when no composite node

### DIFF
--- a/client/ayon_harmony/js/loaders/ImageLoader.js
+++ b/client/ayon_harmony/js/loaders/ImageLoader.js
@@ -84,9 +84,13 @@ PsdLoader.prototype.importPsd = function(psdPath) {
     // Gather nodes in view
     var psdComp = psdNodes[psdNodes.length - 1];
     var sceneComp = doc.$node("Top/Composite");
-    psdComp.linkOutNode(sceneComp);
-    sceneRoot.orderNodeView();
-    psdComp.unlinkOutNode(sceneComp);
+    if (sceneComp) {
+        psdComp.linkOutNode(sceneComp);
+        sceneRoot.orderNodeView();
+        psdComp.unlinkOutNode(sceneComp);
+    } else {
+        sceneRoot.orderNodeView();
+    }
 
     return psdNodes;
 };


### PR DESCRIPTION
## Changelog Description
Fixing broken PSD loading when there is no composite node in scene.


## Testing notes:
1. Open a new scene
2. Remove all composite nodes already existing in scene
3. Load a PSD
