### PR TITLE
Fix: Nested backdrop name override

### DIFF
--- a/client/ayon_harmony/js/AyonHarmony.js
+++ b/client/ayon_harmony/js/AyonHarmony.js
@@ -300,6 +300,89 @@ AyonHarmony.rectsOverlap = function(a, b) {
 };
 
 /**
+ * Check whether one backdrop fully contains another.
+ * @param {object} container Backdrop object with .position.
+ * @param {object} child Backdrop object with .position.
+ * @return {boolean}
+ */
+AyonHarmony.backdropContains = function(container, child) {
+    if (!container || !child || !container.position || !child.position) {
+        return false;
+    }
+    return container.position.x <= child.position.x
+        && container.position.y <= child.position.y
+        && (container.position.x + container.position.w)
+            >= (child.position.x + child.position.w)
+        && (container.position.y + container.position.h)
+            >= (child.position.y + child.position.h);
+};
+
+/**
+ * Find backdrop that contains all other backdrops.
+ * @param {Array} backdrops Backdrop objects.
+ * @return {object|null} Backdrop containing all others, if any.
+ */
+AyonHarmony.findBackdropContainingAll = function(backdrops) {
+    if (!backdrops || backdrops.length === 0) {
+        return null;
+    }
+    if (backdrops.length === 1) {
+        return backdrops[0];
+    }
+    for (var i = 0; i < backdrops.length; i++) {
+        var candidate = backdrops[i];
+        var containsAll = true;
+        for (var j = 0; j < backdrops.length; j++) {
+            if (i === j) {
+                continue;
+            }
+            if (!AyonHarmony.backdropContains(candidate, backdrops[j])) {
+                containsAll = false;
+                break;
+            }
+        }
+        if (containsAll) {
+            return candidate;
+        }
+    }
+    return null;
+};
+
+/**
+ * Find largest backdrop by area.
+ * @param {Array} backdrops Backdrop objects.
+ * @return {object|null} Largest backdrop.
+ */
+AyonHarmony.findLargestBackdrop = function(backdrops) {
+    if (!backdrops || backdrops.length === 0) {
+        return null;
+    }
+    var largest = backdrops[0];
+    for (var i = 1; i < backdrops.length; i++) {
+        var currentArea = backdrops[i].position.w * backdrops[i].position.h;
+        var largestArea = largest.position.w * largest.position.h;
+        if (currentArea > largestArea) {
+            largest = backdrops[i];
+        }
+    }
+    return largest;
+};
+
+/**
+ * Find main backdrop from a collection.
+ * Main backdrop is one containing all others, otherwise the largest.
+ * @param {Array} backdrops Backdrop objects.
+ * @return {object|null} Main backdrop.
+ */
+AyonHarmony.findMainBackdrop = function(backdrops) {
+    var containing = AyonHarmony.findBackdropContainingAll(backdrops);
+    if (containing) {
+        return containing;
+    }
+    return AyonHarmony.findLargestBackdrop(backdrops);
+};
+
+/**
  * Find a non-overlapping area in Top by shifting to the right.
  * @param {object} area Position object {x, y, w, h}.
  * @return {object} Non-overlapping position object {x, y, w, h}.

--- a/client/ayon_harmony/js/loaders/TemplateLoader.js
+++ b/client/ayon_harmony/js/loaders/TemplateLoader.js
@@ -73,7 +73,7 @@ TemplateLoader.prototype.loadContainer = function(args) {
 
     var pastedBackdrops = selection.selectedBackdrops();
     var pastedNodes = selection.selectedNodes();
-    var mainBackdropBeforeMove = pastedBackdrops[0] || null;
+    var mainBackdropBeforeMove = AyonHarmony.findMainBackdrop(pastedBackdrops);
     var parentArea = null;
     if (parentBackdropName) {
         var pastedBounds = AyonHarmony.getContentBounds(


### PR DESCRIPTION
## Changelog Description
Fix name override on nested backdrops at loading by ensuring to rename the main backdrop.

## Additional review information
Loaded backdrops maybe selected in a random order, so we must make sure to get the main one (either the one including all the others or the largest one) before overriding the name.
Bug:
<img width="296" height="156" alt="Capture d’écran 2026-04-27 à 18 33 59" src="https://github.com/user-attachments/assets/e4731b9b-34fc-4cef-acdf-0a0248aba13e" />

Fixed:
<img width="308" height="149" alt="Capture d’écran 2026-04-27 à 18 32 08" src="https://github.com/user-attachments/assets/d12de338-79ac-4c10-9fff-ae1de754d440" />

## Testing notes:
1. Add a custom name override in settings like `{folder[name]}`
2. Load a template with nested backdrops
