### PR TITLE
Fix: Update/Switch doesn't preserve nodetree values

### DIFF
--- a/client/ayon_harmony/api/base_loaders.py
+++ b/client/ayon_harmony/api/base_loaders.py
@@ -141,7 +141,13 @@ class BackdropBaseLoader(load.LoaderPlugin):
         new_backdrop_name = harmony.send(
             {
                 "function": "AyonHarmony.switchContainer",
-                "args": [backdrop, self_name, filepath, name, parent_backdrop_name],
+                "args": [
+                    backdrop,
+                    self_name,
+                    filepath,
+                    name,
+                    parent_backdrop_name,
+                ],
             }
         )["result"]
 

--- a/client/ayon_harmony/api/base_loaders.py
+++ b/client/ayon_harmony/api/base_loaders.py
@@ -124,29 +124,32 @@ class BackdropBaseLoader(load.LoaderPlugin):
 
     def switch(self, container, context):
         """Switch representation containers."""
-        backdrop_name = container["name"]
-        backdrop = harmony.find_backdrop_by_name(backdrop_name)
+        self_name = self.__class__.__name__
+        container_name = container["name"]
+        container_namespace = container["namespace"]
+        backdrop = harmony.find_backdrop_by_name(container_name)
 
-        # Keep backdrop links
-        backdrop_links = harmony.send(
+        filepath = self.filepath_from_context(context)
+        name = container_name
+        if self.override_name:
+            name = self.override_name.format(**context)
+
+        parent_backdrop_name = None
+        if self.parent_backdrop_matching:
+            parent_backdrop_name = self._resolve_parent_backdrop_name(context)
+
+        new_backdrop_name = harmony.send(
             {
-                "function": "AyonHarmony.getBackdropLinks",
-                "args": backdrop,
+                "function": "AyonHarmony.switchContainer",
+                "args": [backdrop, self_name, filepath, name, parent_backdrop_name],
             }
         )["result"]
 
-        # Replace template container
-        self.remove(container)  # Before load to avoid node name incrementation
-        container = self.load(
-            context, container["name"], container["namespace"]
+        harmony.remove(container_name)
+        return harmony.containerise(
+            new_backdrop_name,
+            container_namespace,
+            new_backdrop_name,
+            context,
+            self_name,
         )
-
-        # Restore backdrop links
-        harmony.send(
-            {
-                "function": "AyonHarmony.setNodesLinks",
-                "args": backdrop_links
-            }
-        )
-
-        return container

--- a/client/ayon_harmony/js/AyonHarmony.js
+++ b/client/ayon_harmony/js/AyonHarmony.js
@@ -880,6 +880,9 @@ AyonHarmony.switchContainer = function(args) {
     var overrideName       = args[3] || "";
     var parentBackdropName = args[4] || null;
 
+    selection.clearSelection();
+    $.beginUndo("AYON: Switch Container");
+
     var oldX          = backdrop.position.x;
     var oldY          = backdrop.position.y;
     var backdropLinks = AyonHarmony.getBackdropLinks(backdrop);
@@ -951,6 +954,7 @@ AyonHarmony.switchContainer = function(args) {
     }
 
     AyonHarmony.setNodesLinks(backdropLinks);
+    $.endUndo();
     return newBackdropName;
 };
 

--- a/client/ayon_harmony/js/AyonHarmony.js
+++ b/client/ayon_harmony/js/AyonHarmony.js
@@ -862,13 +862,13 @@ AyonHarmony.setNodesLinks = function(links) {
 
 
 /**
- * Switch a container backdrop: preserves external links and user-modified
- * attribute values across a remove/load cycle.
+ * Switch a container backdrop: loads the new template at the same visual
+ * position as the old one and restores external node links.
  * @function
  * @param {Array} args
  *   [0] {object}      backdrop          Backdrop object (from Backdrop.backdrops).
  *   [1] {string}      loaderName        Key in AyonHarmony.Loaders (e.g. "TemplateLoader").
- *   [2] {string}      templatePath      Ready-to-use template path (e.g. .tpl file).
+ *   [2] {string}      templatePath      Ready-to-use .tpl path.
  *   [3] {string}      overrideName      Backdrop name override (or "").
  *   [4] {string|null} parentBackdropName
  * @return {string} New backdrop name.
@@ -880,9 +880,11 @@ AyonHarmony.switchContainer = function(args) {
     var overrideName       = args[3] || "";
     var parentBackdropName = args[4] || null;
 
-    // Capture external links and attribute snapshots before removing the old container.
+    var oldX          = backdrop.position.x;
+    var oldY          = backdrop.position.y;
     var backdropLinks = AyonHarmony.getBackdropLinks(backdrop);
 
+    // Capture attribute snapshots before removing the old container.
     var nodeSnapshots = {};
     function collectSnapshots(paths) {
         paths.forEach(function(p) {
@@ -900,9 +902,9 @@ AyonHarmony.switchContainer = function(args) {
         [templatePath, overrideName, parentBackdropName]
     );
 
-    // Apply snapshots to the new container, then restore external links.
     var newBackdrop = AyonHarmony.findParentBackdrop(newBackdropName);
     if (newBackdrop) {
+        // Restore attribute snapshots.
         function applySnapshots(paths) {
             paths.forEach(function(p) {
                 if (nodeSnapshots[p]) {
@@ -914,12 +916,41 @@ AyonHarmony.switchContainer = function(args) {
             });
         }
         applySnapshots(Backdrop.nodes(newBackdrop));
+
+        // Shift the newly loaded content to where the old backdrop was.
+        var dx = oldX - newBackdrop.position.x;
+        var dy = oldY - newBackdrop.position.y;
+        if (dx !== 0 || dy !== 0) {
+            Backdrop.nodes(newBackdrop).forEach(function(nodePath) {
+                node.setCoord(
+                    nodePath,
+                    node.coordX(nodePath) + dx,
+                    node.coordY(nodePath) + dy
+                );
+            });
+            var subBackdrops = AyonHarmony.getSubBackdrops(newBackdrop);
+            var allBackdrops = Backdrop.backdrops("Top");
+            allBackdrops.forEach(function(b) {
+                if (b.title.text === newBackdropName) {
+                    b.position.x += dx;
+                    b.position.y += dy;
+                    return;
+                }
+                for (var i = 0; i < subBackdrops.length; i++) {
+                    if (b.title.text === subBackdrops[i].title.text
+                        && b.position.x === subBackdrops[i].position.x
+                        && b.position.y === subBackdrops[i].position.y) {
+                        b.position.x += dx;
+                        b.position.y += dy;
+                        break;
+                    }
+                }
+            });
+            Backdrop.setBackdrops("Top", allBackdrops);
+        }
     }
 
-    // Restore external links after snapshots so internal pegs are at their
-    // user-modified positions before re-linking.
     AyonHarmony.setNodesLinks(backdropLinks);
-
     return newBackdropName;
 };
 

--- a/client/ayon_harmony/js/AyonHarmony.js
+++ b/client/ayon_harmony/js/AyonHarmony.js
@@ -681,41 +681,37 @@ AyonHarmony.getSubBackdrops = function(backdrop) {
  * @return {array} List of nodes links.
  */
 AyonHarmony.getBackdropLinks = function(backdrop) {
-    var backdropNodes = Backdrop.nodes(backdrop);
+    // Collect all nodes recursively (including those inside groups) so links
+    // between deep-nested nodes and nodes outside the backdrop are captured.
+    var backdropTopNodes = Backdrop.nodes(backdrop);
+    var backdropNodes = [];
+    function collect(paths) {
+        paths.forEach(function(p) {
+            backdropNodes.push(p);
+            var subs = node.subNodes(p);
+            if (subs && subs.length > 0) collect(subs);
+        });
+    }
+    collect(backdropTopNodes);
+
     var nodesLinks = [];
 
-    // Input links
+    // Input links — nodes outside the backdrop feeding into it.
     backdropNodes.forEach(function(n) {
         for (var i = 0; i < node.numberOfInputPorts(n); i++) {
             var link = node.srcNodeInfo(n, i);
-
-            // Skip if no link or if it's a node from the backdrop container
             if (link == null || backdropNodes.indexOf(link.node) > -1) continue;
-
-            nodesLinks.push({
-                srcNode: link.node,
-                srcPort: link.port,
-                dstNode: n,
-                dstPort: i,
-            });
+            nodesLinks.push({ srcNode: link.node, srcPort: link.port, dstNode: n, dstPort: i });
         }
     });
 
-    // Output links
+    // Output links — backdrop nodes feeding into nodes outside.
     backdropNodes.forEach(function(n) {
         for (var i = 0; i < node.numberOfOutputPorts(n); i++) {
             for (var j = 0; j < node.numberOfOutputLinks(n, i); j++) {
                 var link = node.dstNodeInfo(n, i, j);
-
-                // Skip if no link or if it's a node from the backdrop container
                 if (link == null || backdropNodes.indexOf(link.node) > -1) continue;
-
-                nodesLinks.push({
-                    srcNode: n,
-                    srcPort: i,
-                    dstNode: link.node,
-                    dstPort: link.port
-                });
+                nodesLinks.push({ srcNode: n, srcPort: i, dstNode: link.node, dstPort: link.port });
             }
         }
     });
@@ -863,6 +859,70 @@ AyonHarmony.setNodesLinks = function(links) {
         node.link(l.srcNode, l.srcPort, l.dstNode, l.dstPort);
     });
 };
+
+
+/**
+ * Switch a container backdrop: preserves external links and user-modified
+ * attribute values across a remove/load cycle.
+ * @function
+ * @param {Array} args
+ *   [0] {object}      backdrop          Backdrop object (from Backdrop.backdrops).
+ *   [1] {string}      loaderName        Key in AyonHarmony.Loaders (e.g. "TemplateLoader").
+ *   [2] {string}      templatePath      Ready-to-use template path (e.g. .tpl file).
+ *   [3] {string}      overrideName      Backdrop name override (or "").
+ *   [4] {string|null} parentBackdropName
+ * @return {string} New backdrop name.
+ */
+AyonHarmony.switchContainer = function(args) {
+    var backdrop           = args[0];
+    var loaderName         = args[1];
+    var templatePath       = args[2];
+    var overrideName       = args[3] || "";
+    var parentBackdropName = args[4] || null;
+
+    // Capture external links and attribute snapshots before removing the old container.
+    var backdropLinks = AyonHarmony.getBackdropLinks(backdrop);
+
+    var nodeSnapshots = {};
+    function collectSnapshots(paths) {
+        paths.forEach(function(p) {
+            var oN = $.scene.getNodeByPath(p);
+            if (oN) nodeSnapshots[p] = oN.getAttributeSnapshot();
+            var subs = node.subNodes(p);
+            if (subs && subs.length > 0) collectSnapshots(subs);
+        });
+    }
+    collectSnapshots(Backdrop.nodes(backdrop));
+
+    // Swap container.
+    AyonHarmony.removeBackdrop([backdrop, true]);
+    var newBackdropName = AyonHarmony.Loaders[loaderName].loadContainer(
+        [templatePath, overrideName, parentBackdropName]
+    );
+
+    // Apply snapshots to the new container, then restore external links.
+    var newBackdrop = AyonHarmony.findParentBackdrop(newBackdropName);
+    if (newBackdrop) {
+        function applySnapshots(paths) {
+            paths.forEach(function(p) {
+                if (nodeSnapshots[p]) {
+                    var oN = $.scene.getNodeByPath(p);
+                    if (oN) oN.applyAttributeSnapshot(nodeSnapshots[p]);
+                }
+                var subs = node.subNodes(p);
+                if (subs && subs.length > 0) applySnapshots(subs);
+            });
+        }
+        applySnapshots(Backdrop.nodes(newBackdrop));
+    }
+
+    // Restore external links after snapshots so internal pegs are at their
+    // user-modified positions before re-linking.
+    AyonHarmony.setNodesLinks(backdropLinks);
+
+    return newBackdropName;
+};
+
 
 /**
  * Remove backdrop and its contents.

--- a/client/ayon_harmony/js/loaders/TemplateLoader.js
+++ b/client/ayon_harmony/js/loaders/TemplateLoader.js
@@ -68,95 +68,109 @@ TemplateLoader.prototype.loadContainer = function(args) {
 
     // Paste into scene
     var pasteOptions = copyPaste.getCurrentPasteOptions();
-    pasteOptions.extendScene = true; // TODO does this work?
-    copyPaste.pasteNewNodes(_tpl, "Top", pasteOptions);
-
-    var pastedBackdrops = selection.selectedBackdrops();
-    var pastedNodes = selection.selectedNodes();
-    var mainBackdropBeforeMove = pastedBackdrops[0] || null;
-    var parentArea = null;
-    if (parentBackdropName) {
-        var pastedBounds = AyonHarmony.getContentBounds(
-            pastedBackdrops, pastedNodes
+    pasteOptions.extendScene = true;
+    $.beginUndo('AYON: Load Template');
+    try {
+        copyPaste.pasteNewNodes(_tpl, "Top", pasteOptions);
+        var pastedBackdrops = selection.selectedBackdrops();
+        var _allSelected = selection.selectedNodes();
+        var topPastedNodes = _allSelected.filter(
+            function(nodePath) { return node.parentNode(nodePath) === "Top"; }
         );
-        var parentBackdrop = AyonHarmony.ensureParentBackdrop(
-            parentBackdropName, pastedBounds
+        var mainBackdropBeforeMove = AyonHarmony.findMainBackdrop(pastedBackdrops);
+        var parentArea = null;
+        if (parentBackdropName) {
+            var pastedBounds = AyonHarmony.getContentBounds(
+                pastedBackdrops, topPastedNodes
+            );
+            var parentBackdrop = AyonHarmony.ensureParentBackdrop(
+                parentBackdropName, pastedBounds
+            );
+            parentArea = {
+                x: parentBackdrop.position.x,
+                y: parentBackdrop.position.y,
+                w: parentBackdrop.position.w,
+                h: parentBackdrop.position.h
+            };
+        }
+
+        var overlapResult = AyonHarmony.preventOverlap(
+            pastedBackdrops, topPastedNodes, parentArea, parentBackdropName
         );
-        parentArea = {
-            x: parentBackdrop.position.x,
-            y: parentBackdrop.position.y,
-            w: parentBackdrop.position.w,
-            h: parentBackdrop.position.h
-        };
-    }
+        var allBackdrops = overlapResult.allBackdrops;
 
-    var overlapResult = AyonHarmony.preventOverlap(
-        pastedBackdrops, pastedNodes, parentArea, parentBackdropName
-    );
-    var allBackdrops = overlapResult.allBackdrops;
+        if (parentBackdropName && overlapResult.area && parentArea &&
+            (overlapResult.area.x !== parentArea.x ||
+            overlapResult.area.y !== parentArea.y ||
+            overlapResult.area.w !== parentArea.w ||
+            overlapResult.area.h !== parentArea.h)) {
+            allBackdrops = AyonHarmony.applyAreaToBackdrop(
+                parentBackdropName, overlapResult.area
+            );
+        }
 
-    if (parentBackdropName && overlapResult.area && parentArea &&
-        (overlapResult.area.x !== parentArea.x ||
-        overlapResult.area.y !== parentArea.y ||
-        overlapResult.area.w !== parentArea.w ||
-        overlapResult.area.h !== parentArea.h)) {
-        allBackdrops = AyonHarmony.applyAreaToBackdrop(
-            parentBackdropName, overlapResult.area
-        );
-    }
-
-    var mainBackdrop = null;
-    if (mainBackdropBeforeMove) {
-        for (var backdropIndex = 0; backdropIndex < allBackdrops.length; backdropIndex++) {
-            var backdrop = allBackdrops[backdropIndex];
-            if (backdrop.title.text === mainBackdropBeforeMove.title.text &&
-                backdrop.position.w === mainBackdropBeforeMove.position.w &&
-                backdrop.position.h === mainBackdropBeforeMove.position.h) {
-                mainBackdrop = backdrop;
-                break;
+        var mainBackdrop = null;
+        if (mainBackdropBeforeMove) {
+            for (var backdropIndex = 0; backdropIndex < allBackdrops.length; backdropIndex++) {
+                var backdrop = allBackdrops[backdropIndex];
+                if (backdrop.title.text === mainBackdropBeforeMove.title.text &&
+                    backdrop.position.w === mainBackdropBeforeMove.position.w &&
+                    backdrop.position.h === mainBackdropBeforeMove.position.h) {
+                    mainBackdrop = backdrop;
+                    break;
+                }
             }
         }
-    }
-    if (!mainBackdrop && allBackdrops.length > 0) {
-        mainBackdrop = allBackdrops[0];
-    }
-    if (!mainBackdrop) {
-        return "";
-    }
-
-    // Override name if provided
-    if (overrideName) {
-        mainBackdrop.title.text = overrideName;
-    }
-
-    // Count existing backdrops by base name
-    var backdropCounts = {};
-    for (var i = 0; i < allBackdrops.length; i++) {
-        var parsed = parseBackdropName(allBackdrops[i].title.text);
-        var baseName = parsed.baseName;
-        var count = parsed.count;
-
-        if (backdropCounts[baseName]) {
-            backdropCounts[baseName]++;
-        } else {
-            backdropCounts[baseName] = count;
+        if (!mainBackdrop && allBackdrops.length > 0) {
+            mainBackdrop = allBackdrops[0];
         }
+        if (!mainBackdrop) {
+            $.cancelUndo();
+            return "";
+        }
+
+        // Override name if provided
+        if (overrideName) {
+            mainBackdrop.title.text = overrideName;
+        }
+
+        // Count existing backdrops by base name
+        var backdropCounts = {};
+        for (var i = 0; i < allBackdrops.length; i++) {
+            var parsed = parseBackdropName(allBackdrops[i].title.text);
+            var baseName = parsed.baseName;
+            var count = parsed.count;
+
+            if (backdropCounts[baseName]) {
+                backdropCounts[baseName]++;
+            } else {
+                backdropCounts[baseName] = count;
+            }
+        }
+
+        // Increment count of backdrop with the same base name
+        var mainBackdropName = mainBackdrop.title.text;
+        var mainBackdropParsed = parseBackdropName(mainBackdropName);
+        var count = backdropCounts[mainBackdropParsed.baseName] !== undefined ? backdropCounts[mainBackdropParsed.baseName] : 1;
+        if (count > 1){
+            // count -1 to match imported nodes which start from _1
+            mainBackdropName = mainBackdropName + "_" + (count - 1);
+        }
+
+        // Set name of main backdrop (always at index 0)
+        mainBackdrop.title.text = mainBackdropName;
+
+        // Update backdrops in scene
+        Backdrop.setBackdrops("Top", allBackdrops);
+    } catch (_err) {
+        $.cancelUndo();
+        throw _err;
     }
-
-    // Increment count of backdrop with the same base name
-    var mainBackdropName = mainBackdrop.title.text;
-    var mainBackdropParsed = parseBackdropName(mainBackdropName);
-    var count = backdropCounts[mainBackdropParsed.baseName] !== undefined ? backdropCounts[mainBackdropParsed.baseName] : 1;
-    if (count > 1){
-        // count -1 to match imported nodes which start from _1
-        mainBackdropName = mainBackdropName + "_" + (count - 1);
+    try {
+        $.endUndo();
+    } catch (_endErr) {
+        // Scene data is already committed; safe to ignore.
     }
-
-    // Set name of main backdrop (always at index 0)
-    mainBackdrop.title.text = mainBackdropName;
-
-    // Update backdrops in scene
-    Backdrop.setBackdrops("Top", allBackdrops);
 
     return mainBackdropName;
 };

--- a/client/ayon_harmony/plugins/load/load_template.py
+++ b/client/ayon_harmony/plugins/load/load_template.py
@@ -71,7 +71,7 @@ class TemplateLoader(harmony.BackdropBaseLoader):
         )
 
     def switch(self, container, context):
-        """Switch representation containers (zip → tpl extraction before JS)."""
+        """Switch representation containers."""
         self_name = self.__class__.__name__
         container_name = container["name"]
         container_namespace = container["namespace"]
@@ -104,7 +104,7 @@ class TemplateLoader(harmony.BackdropBaseLoader):
                 ],
             }
         )["result"]
-    
+
         # Cleanup the temp directory
         shutil.rmtree(temp_dir)
 

--- a/client/ayon_harmony/plugins/load/load_template.py
+++ b/client/ayon_harmony/plugins/load/load_template.py
@@ -69,3 +69,50 @@ class TemplateLoader(harmony.BackdropBaseLoader):
             context,
             self_name
         )
+
+    def switch(self, container, context):
+        """Switch representation containers (zip → tpl extraction before JS)."""
+        self_name = self.__class__.__name__
+        container_name = container["name"]
+        container_namespace = container["namespace"]
+        backdrop = harmony.find_backdrop_by_name(container_name)
+
+        override_name = ""
+        if self.override_name:
+            override_name = self.override_name.format(**context)
+
+        parent_backdrop_name = None
+        if self.parent_backdrop_matching:
+            parent_backdrop_name = self._resolve_parent_backdrop_name(context)
+
+        temp_dir = tempfile.mkdtemp()
+        zip_path = self.filepath_from_context(context)
+        with zipfile.ZipFile(zip_path, "r") as zip_ref:
+            zip_ref.extractall(temp_dir)
+        template_path = next(Path(temp_dir).glob("*.tpl")).as_posix()
+
+        # Everything (snapshot, remove, load, restore) in one JS call
+        new_backdrop_name = harmony.send(
+            {
+                "function": "AyonHarmony.switchContainer",
+                "args": [
+                    backdrop,
+                    self_name,
+                    template_path,
+                    override_name,
+                    parent_backdrop_name,
+                ],
+            }
+        )["result"]
+    
+        # Cleanup the temp directory
+        shutil.rmtree(temp_dir)
+
+        harmony.remove(container_name)
+        return harmony.containerise(
+            new_backdrop_name,
+            container_namespace,
+            new_backdrop_name,
+            context,
+            self_name,
+        )


### PR DESCRIPTION
## Changelog Description
Switch/Update a template preserves nodetree values and location.

## Additional review information
In case you start working with a template and you want to update it at some point (e.g when moving from layout to animation)
NB: Relies on https://github.com/cfourney/OpenHarmony/pull/86, so we should wait for it to be merged in OpenHarmony (draft PR until then).

## Testing notes:
1. Load an out of date version of a template
2. In Manage, update to latest
