### PR TITLE
Fix: Cannot publish twice

### DIFF
--- a/client/ayon_harmony/plugins/publish/extract_template.py
+++ b/client/ayon_harmony/plugins/publish/extract_template.py
@@ -30,7 +30,8 @@ class ExtractTemplate(publish.Extractor):
 
         # Prep representation.
         shutil.make_archive(
-            base_name=Path(staging_dir, instance.name),
+            base_name=instance.name,
+            base_dir=staging_dir,
             format="zip",
             root_dir=Path(staging_dir, "harmony"),
         )

--- a/client/ayon_harmony/plugins/publish/extract_template.py
+++ b/client/ayon_harmony/plugins/publish/extract_template.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Extract template."""
 import os
+from pathlib import Path
 import shutil
 
 from ayon_core.pipeline import publish
@@ -28,11 +29,10 @@ class ExtractTemplate(publish.Extractor):
         )
 
         # Prep representation.
-        os.chdir(staging_dir)
         shutil.make_archive(
-            f"{instance.name}",
-            "zip",
-            os.path.join(staging_dir, "harmony"),
+            base_name=Path(staging_dir, instance.name),
+            format="zip",
+            root_dir=Path(staging_dir, "harmony"),
         )
 
         representation = {

--- a/client/ayon_harmony/plugins/publish/extract_workfile.py
+++ b/client/ayon_harmony/plugins/publish/extract_workfile.py
@@ -31,7 +31,8 @@ class ExtractWorkfile(publish.Extractor):
 
         # Prep representation.
         shutil.make_archive(
-            base_name=Path(staging_dir, instance.name),
+            base_name=instance.name,
+            base_dir=staging_dir,
             format="zip",
             root_dir=Path(staging_dir, f"{instance.name}.tpl")
         )

--- a/client/ayon_harmony/plugins/publish/extract_workfile.py
+++ b/client/ayon_harmony/plugins/publish/extract_workfile.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Extract work file."""
 import os
+from pathlib import Path
 import platform
 import shutil
 from zipfile import ZipFile
@@ -29,18 +30,15 @@ class ExtractWorkfile(publish.Extractor):
         shutil.copytree(src, filepath)
 
         # Prep representation.
-        prev_cwd = os.getcwd()
-        os.chdir(staging_dir)
         shutil.make_archive(
-            f"{instance.name}",
-            "zip",
-            os.path.join(staging_dir, f"{instance.name}.tpl")
+            base_name=Path(staging_dir, instance.name),
+            format="zip",
+            root_dir=Path(staging_dir, f"{instance.name}.tpl")
         )
         # Check if archive is ok
-        with ZipFile(os.path.basename(f"{instance.name}.zip")) as zr:
+        with ZipFile(Path(staging_dir, f"{instance.name}.zip")) as zr:
             if zr.testzip() is not None:
                 raise Exception("File archive is corrupted.")
-        os.chdir(prev_cwd)
 
         representation = {
             "name": "tpl",


### PR DESCRIPTION
## Changelog Description
Fixing error when publishing twice the same workfile.

## Additional review information
I can see it is likely the same error as https://github.com/ynput/ayon-harmony/pull/121/changes. I'm still proposing my code because I think using `chdir` is more error prone than passing the correct args to `make_archive`. I'll let you decide.

## Testing notes:
1. On version `0.5.0`, publish twice the same workfile
