### PR TITLE
Fix: broken extract workfile and template

### DIFF
--- a/client/ayon_harmony/plugins/publish/extract_template.py
+++ b/client/ayon_harmony/plugins/publish/extract_template.py
@@ -30,8 +30,7 @@ class ExtractTemplate(publish.Extractor):
 
         # Prep representation.
         shutil.make_archive(
-            base_name=instance.name,
-            base_dir=staging_dir,
+            base_name=Path(staging_dir, instance.name),
             format="zip",
             root_dir=Path(staging_dir, "harmony"),
         )

--- a/client/ayon_harmony/plugins/publish/extract_workfile.py
+++ b/client/ayon_harmony/plugins/publish/extract_workfile.py
@@ -31,8 +31,7 @@ class ExtractWorkfile(publish.Extractor):
 
         # Prep representation.
         shutil.make_archive(
-            base_name=instance.name,
-            base_dir=staging_dir,
+            base_name=Path(staging_dir, instance.name),
             format="zip",
             root_dir=Path(staging_dir, f"{instance.name}.tpl")
         )


### PR DESCRIPTION
## Changelog Description
Fixes issue in `extract_workfile.py` where it couldn't find zipped file.

## Additional review information
This reverts commit e3e3295f271c717717d0016ac9a8d8e034c29708.

`base_name` and `base_dir` are not bind together to create path for final zip.


## Testing notes:
1. publish workfile in Harmony
