### PR TITLE
Feature: ensure scene settings at scene opening

### DIFF
--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -240,7 +240,7 @@ def application_launch(event):
     harmony.send({"script": script})
     inject_ayon_js()
 
-    # ensure_scene_settings()
+    ensure_scene_settings()
     check_inventory()
 
 


### PR DESCRIPTION
## Changelog Description
Ensure scene settings at file opening.

## Additional review information
I don't know why this has been left commented. I believe @BigRoy may have some information.

## Testing notes:
1. Open a scene
2. Change timeline duration, save and close
3. Open the same scene again, settings are restored.
