### PR TITLE
Feature: Save as dialog for new scene

### DIFF
--- a/client/ayon_harmony/api/lib.py
+++ b/client/ayon_harmony/api/lib.py
@@ -43,7 +43,8 @@ from .server import Server
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
-TEMP_WORKFILE_NAME = "temp.zip"
+CURRENT_DIR = Path(__file__).parent.absolute()
+TEMP_WORKFILE_PATH = CURRENT_DIR / "temp.zip"
 
 
 class ProcessContext:
@@ -284,11 +285,11 @@ def check_workfiles_tool():
 
 def is_temp_workfile(filepath):
     """Check if filepath points to the temporary scratch workfile."""
-    return Path(filepath).name == TEMP_WORKFILE_NAME
+    return Path(filepath) == TEMP_WORKFILE_PATH
 
 
 def open_empty_workfile():
-    zip_file = os.path.join(os.path.dirname(__file__), TEMP_WORKFILE_NAME)
+    zip_file = str(TEMP_WORKFILE_PATH)
     temp_path = get_local_harmony_path(zip_file)
     if os.path.exists(temp_path):
         log.info(f"removing existing {temp_path}")

--- a/client/ayon_harmony/api/lib.py
+++ b/client/ayon_harmony/api/lib.py
@@ -289,7 +289,7 @@ def is_temp_workfile(filepath):
 
 
 def open_empty_workfile():
-    zip_file = str(TEMP_WORKFILE_PATH)
+    zip_file = TEMP_WORKFILE_PATH.as_posix()
     temp_path = get_local_harmony_path(zip_file)
     if os.path.exists(temp_path):
         log.info(f"removing existing {temp_path}")

--- a/client/ayon_harmony/api/lib.py
+++ b/client/ayon_harmony/api/lib.py
@@ -43,6 +43,8 @@ from .server import Server
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
+TEMP_WORKFILE_NAME = "temp.zip"
+
 
 class ProcessContext:
     server = None
@@ -280,8 +282,13 @@ def check_workfiles_tool():
         open_empty_workfile()
 
 
+def is_temp_workfile(filepath):
+    """Check if filepath points to the temporary scratch workfile."""
+    return Path(filepath).name == TEMP_WORKFILE_NAME
+
+
 def open_empty_workfile():
-    zip_file = os.path.join(os.path.dirname(__file__), "temp.zip")
+    zip_file = os.path.join(os.path.dirname(__file__), TEMP_WORKFILE_NAME)
     temp_path = get_local_harmony_path(zip_file)
     if os.path.exists(temp_path):
         log.info(f"removing existing {temp_path}")

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -5,7 +5,10 @@ import logging
 from qtpy import QtWidgets
 
 from ayon_core import style
-from ayon_core.tools.utils.host_tools import show_scene_inventory
+from ayon_core.tools.utils.host_tools import (
+    show_scene_inventory,
+    show_workfiles,
+)
 import pyblish.api
 
 from ayon_core.lib import is_headless_mode_enabled, register_event_callback
@@ -35,6 +38,7 @@ from .lib import (
     ProcessContext,
     get_scene_data,
     set_scene_data,
+    is_temp_workfile,
 )
 from .workio import (
     open_file,
@@ -176,27 +180,61 @@ def ensure_scene_settings():
     set_scene_settings(valid_settings)
 
 
-def prompt_outdated_containers():
-    """Show outdated containers warning with option to open Scene Inventory."""
-    # Don't show UI in headless mode
+def _prompt_simple_choice(
+    title, text, accept_label, reject_label, informative_text=None
+):
+    """Show a modal warning dialog with two choices.
+
+    Returns:
+        bool: True if the accept button was clicked, False otherwise
+            (including when skipped in headless mode).
+    """
     if is_headless_mode_enabled():
-        return
+        return False
 
     msg_box = QtWidgets.QMessageBox()
     msg_box.setStyleSheet(style.load_stylesheet())
     msg_box.setIcon(QtWidgets.QMessageBox.Warning)
-    msg_box.setWindowTitle("Outdated Containers")
-    msg_box.setText("There are outdated containers in the scene.")
-    manage_button = msg_box.addButton(
-        "Manage", QtWidgets.QMessageBox.AcceptRole
+    msg_box.setWindowTitle(title)
+    msg_box.setText(text)
+    if informative_text:
+        msg_box.setInformativeText(informative_text)
+
+    accept_button = msg_box.addButton(
+        accept_label, QtWidgets.QMessageBox.AcceptRole
     )
-    msg_box.addButton("Dismiss", QtWidgets.QMessageBox.RejectRole)
-    msg_box.setDefaultButton(manage_button)
+    msg_box.addButton(reject_label, QtWidgets.QMessageBox.RejectRole)
+    msg_box.setDefaultButton(accept_button)
     msg_box.setModal(True)
     msg_box.exec_()
 
-    if msg_box.clickedButton() == manage_button:
+    return msg_box.clickedButton() == accept_button
+
+
+def prompt_outdated_containers():
+    """Show outdated containers warning with option to open Scene Inventory."""
+    if _prompt_simple_choice(
+        title="Outdated Containers",
+        text="There are outdated containers in the scene.",
+        accept_label="Manage",
+        reject_label="Dismiss",
+    ):
         show_scene_inventory()
+
+
+def prompt_new_workfile():
+    """Prompt user that they are working on the temporary workfile."""
+    if _prompt_simple_choice(
+        title="New Workfile",
+        text="You are working on a new, unsaved workfile.",
+        accept_label="Open Workfiles Window",
+        reject_label="Ignore",
+        informative_text=(
+            "Open the Workfiles window to save it, or continue working "
+            "on the temporary scene."
+        ),
+    ):
+        show_workfiles(save=True)
 
 
 def check_inventory():
@@ -242,6 +280,9 @@ def application_launch(event):
 
     # ensure_scene_settings()
     check_inventory()
+
+    if is_temp_workfile(ProcessContext.workfile_path):
+        prompt_new_workfile()
 
 
 def export_backdrop_as_template(backdrop, filepath):

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -282,7 +282,7 @@ def application_launch(event):
     check_inventory()
 
     if is_temp_workfile(ProcessContext.workfile_path):
-        prompt_new_workfile()
+        ProcessContext.execute_in_main_thread(prompt_new_workfile())
 
 
 def export_backdrop_as_template(backdrop, filepath):


### PR DESCRIPTION
## Changelog Description
Prompt save as workfile to user when working on temp file.

## Additional review information
Because Harmony doesn't support unsaved scenes, we have to use temp scene file. But this behaviour can cause work loss if the artist leaves its work to the temp file without saving as for a moment, expecting to retrieve it back later. If they open another blank task, the temp file will be overriden, erasing all previous work. Prompting them to do it directly reduces this error.
I considered doing it automatically without asking anything, but it could be confusing if you basically want to draft something on a task, for debugging or so, without creating a new referenced workfile.
I reused previous logic from outdated container prompt dialog.

## Testing notes:
1. Open a task which has no any workfile
2. Deal with the prompted message
