### PR TITLE
Enhancement: Allow server options for automatic resolution of "Local cache of version exists" dialog

### DIFF
--- a/client/ayon_harmony/api/lib.py
+++ b/client/ayon_harmony/api/lib.py
@@ -28,6 +28,8 @@ from ayon_core.lib import (
     env_value_to_bool,
     register_event_callback,
 )
+from ayon_core.pipeline import get_current_project_name
+from ayon_core.settings import get_project_settings
 from ayon_core.tools.stdout_broker import StdOutBroker
 from ayon_core.tools.utils import host_tools
 from ayon_core import style
@@ -404,6 +406,11 @@ def copy_with_progress(src, dst):
     log.info(f"Successfully copied {src} to {dst}")
 
 
+def get_harmony_settings():
+    project = get_current_project_name()
+    return get_project_settings(project).get("harmony")
+
+
 def unzip_scene_file(filepath: str, headless: bool = False) -> str:
     """Unzip a Harmony scene file and return the path to the .xstage file.
 
@@ -449,30 +456,51 @@ def unzip_scene_file(filepath: str, headless: bool = False) -> str:
             )
             unzip = False
         else:
-            # Local is newer or same timestamp - ask user
-            msg_box = QtWidgets.QMessageBox()
-            msg_box.setStyleSheet(style.load_stylesheet())
-            msg_box.setIcon(QtWidgets.QMessageBox.Question)
-            msg_box.setWindowTitle("Local cache of version exists")
-            msg_box.setText(
-                "A cached version of this scene exists that is newer or "
-                "with the same timestamp as the server version."
-            )
-            msg_box.setInformativeText(
-                "Do you want to use the local file or "
-                "re-cache from the server?"
-            )
-            msg_box.setStandardButtons(
-                QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No
-            )
-            msg_box.setDefaultButton(QtWidgets.QMessageBox.Yes)
+            # Local is newer or same timestamp - ask user or defer to settings.
 
-            msg_box.button(QtWidgets.QMessageBox.Yes).setText("Use Local")
-            msg_box.button(QtWidgets.QMessageBox.No).setText("From Server")
+            use_default = False
+            default_opt = QtWidgets.QMessageBox.Yes
+            harmony_settings = get_harmony_settings()
+            cache_settings = (
+                harmony_settings.get("cache_default") if harmony_settings
+                else None
+            )
 
-            msg_box.setModal(True)
+            if cache_settings:
+                use_default = cache_settings.get("use_default_setting")
+                default_opt = {
+                    "local": QtWidgets.QMessageBox.Yes,
+                    "server": QtWidgets.QMessageBox.No,
+                }.get(cache_settings.get("cache_default", "local"))
 
-            result = msg_box.exec_()
+            result = None
+
+            if not use_default:
+                msg_box = QtWidgets.QMessageBox()
+                msg_box.setStyleSheet(style.load_stylesheet())
+                msg_box.setIcon(QtWidgets.QMessageBox.Question)
+                msg_box.setWindowTitle("Local cache of version exists")
+                msg_box.setText(
+                    "A cached version of this scene exists that is newer or "
+                    "with the same timestamp as the server version."
+                )
+                msg_box.setInformativeText(
+                    "Do you want to use the local file or "
+                    "re-cache from the server?"
+                )
+                msg_box.setStandardButtons(
+                    QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No
+                )
+                msg_box.setDefaultButton(QtWidgets.QMessageBox.Yes)
+
+                msg_box.button(QtWidgets.QMessageBox.Yes).setText("Use Local")
+                msg_box.button(QtWidgets.QMessageBox.No).setText("From Server")
+
+                msg_box.setModal(True)
+
+                result = msg_box.exec_()
+            else:
+                result = default_opt
 
             if result == QtWidgets.QMessageBox.No:
                 try:

--- a/client/ayon_harmony/api/lib.py
+++ b/client/ayon_harmony/api/lib.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 """Utility functions used for AYON - Harmony integration."""
+
+from __future__ import annotations
+
 from pathlib import Path
 import platform
 import subprocess
@@ -457,23 +460,15 @@ def unzip_scene_file(filepath: str, headless: bool = False) -> str:
             unzip = False
         else:
             # Local is newer or same timestamp - ask user or defer to settings.
-
-            use_default = False
-            default_opt = QtWidgets.QMessageBox.Yes
             harmony_settings = get_harmony_settings()
-            cache_settings = (
-                harmony_settings.get("cache_default") if harmony_settings
-                else None
-            )
+            use_default = False
+            cache_settings = harmony_settings.get("cache_default")
+            use_default = cache_settings.get("force_default")
+            default_opt = QtWidgets.QMessageBox.Yes
+            if cache_settings["cache_default_source"] == "server":
+                default_opt = QtWidgets.QMessageBox.No
 
-            if cache_settings:
-                use_default = cache_settings.get("use_default_setting")
-                default_opt = {
-                    "local": QtWidgets.QMessageBox.Yes,
-                    "server": QtWidgets.QMessageBox.No,
-                }.get(cache_settings.get("cache_default", "local"))
-
-            result = None
+            result = default_opt
 
             if not use_default:
                 msg_box = QtWidgets.QMessageBox()
@@ -499,8 +494,6 @@ def unzip_scene_file(filepath: str, headless: bool = False) -> str:
                 msg_box.setModal(True)
 
                 result = msg_box.exec_()
-            else:
-                result = default_opt
 
             if result == QtWidgets.QMessageBox.No:
                 try:

--- a/server/settings/cache_default.py
+++ b/server/settings/cache_default.py
@@ -11,7 +11,7 @@ def cache_enum():
 class HarmonyCacheDefaultSettings(BaseSettingsModel):
     """Settings regarding behavior on detection of newer cache."""
 
-    use_default_setting: bool = SettingsField(
+    force_default: bool = SettingsField(
         default=False,
         title="Force cache conflict source",
         description=(
@@ -21,7 +21,7 @@ class HarmonyCacheDefaultSettings(BaseSettingsModel):
         )
     )
 
-    cache_default: str = SettingsField(
+    cache_default_source: str = SettingsField(
         "server",
         enum_resolver=cache_enum,
         title="Conflict source",

--- a/server/settings/cache_default.py
+++ b/server/settings/cache_default.py
@@ -1,0 +1,33 @@
+from ayon_server.settings import BaseSettingsModel, SettingsField
+
+
+def cache_enum():
+    return [
+        {"value": "local", "label": "Use Local"},
+        {"value": "server", "label": "From Server"},
+    ]
+
+
+class HarmonyCacheDefaultSettings(BaseSettingsModel):
+    """Settings regarding behavior on detection of newer cache."""
+
+    use_default_setting: bool = SettingsField(
+        default=False,
+        title="Use cache conflict default source",
+        description=(
+            "When a newer local version is detected, "
+            "instead of prompting a dialog, always use "
+            "local or pull from server"
+        )
+    )
+
+    cache_default: str = SettingsField(
+        "server",
+        enum_resolver=cache_enum,
+        title="Default source",
+        description=(
+            "Use Local will always pull from locally cached file "
+            "if it's newer. From server will attempt to get a known version "
+            "from server."
+        )
+    )

--- a/server/settings/cache_default.py
+++ b/server/settings/cache_default.py
@@ -13,7 +13,7 @@ class HarmonyCacheDefaultSettings(BaseSettingsModel):
 
     use_default_setting: bool = SettingsField(
         default=False,
-        title="Use cache conflict default source",
+        title="Force cache conflict source",
         description=(
             "When a newer local version is detected, "
             "instead of prompting a dialog, always use "
@@ -24,7 +24,7 @@ class HarmonyCacheDefaultSettings(BaseSettingsModel):
     cache_default: str = SettingsField(
         "server",
         enum_resolver=cache_enum,
-        title="Default source",
+        title="Conflict source",
         description=(
             "Use Local will always pull from locally cached file "
             "if it's newer. From server will attempt to get a known version "

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -16,7 +16,7 @@ class HarmonySettings(BaseSettingsModel):
     )
     cache_default: HarmonyCacheDefaultSettings = SettingsField(
         default_factory=HarmonyCacheDefaultSettings,
-        title="Default cache conflict source",
+        title="Cache conflict resolution",
     )
     load: HarmonyLoadPlugins = SettingsField(
         default_factory=HarmonyLoadPlugins,

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -96,7 +96,7 @@ DEFAULT_HARMONY_SETTING = {
     },
     "cache_default": {
         "force_default": False,
-        "cache_default": "server",
+        "cache_default_source": "server",
     },
     "load": {
         "override_name": "",

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -95,7 +95,7 @@ DEFAULT_HARMONY_SETTING = {
         }
     },
     "cache_default": {
-        "use_default_setting": False,
+        "force_default": False,
         "cache_default": "server",
     },
     "load": {

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -1,8 +1,9 @@
 from ayon_server.settings import BaseSettingsModel, SettingsField
 
+from .cache_default import HarmonyCacheDefaultSettings
+from .creator_plugins import HarmonyCreatePlugins
 from .imageio import HarmonyImageIOModel
 from .load_plugins import HarmonyLoadPlugins
-from .creator_plugins import HarmonyCreatePlugins
 from .publish_plugins import HarmonyPublishPlugins
 
 
@@ -12,6 +13,10 @@ class HarmonySettings(BaseSettingsModel):
     imageio: HarmonyImageIOModel = SettingsField(
         default_factory=HarmonyImageIOModel,
         title="OCIO config"
+    )
+    cache_default: HarmonyCacheDefaultSettings = SettingsField(
+        default_factory=HarmonyCacheDefaultSettings,
+        title="Default cache conflict source",
     )
     load: HarmonyLoadPlugins = SettingsField(
         default_factory=HarmonyLoadPlugins,
@@ -88,6 +93,10 @@ DEFAULT_HARMONY_SETTING = {
                 "template": "G{group_index}_L{layer_index}_{variant}"
             }
         }
+    },
+    "cache_default": {
+        "use_default_setting": False,
+        "cache_default": "server",
     },
     "load": {
         "override_name": "",


### PR DESCRIPTION
This PR adds a server option for automatically resolving the dialog that pops up when a newer, locally cached file is present.
This allows TDs setting up the plugin to be strict about there source of truth, instead of leaving it to the artist.
The PR was set up following a discussion within the community about this dialog's choice leaving a workflow vulnerable to loss of work.

The new options are disabled by default, and without enabling the "Force cache conflict source" option, in "Cache conflict resolution", the dialog will still pop up.

Thanks for your consideration,

Sas van Gulik

## Changelog Description
This PR adds a server-side toggle + enum with corresponding options found in the "Local cache of version exists" dialog's buttons.
It allows the user to set a default strategy if that is wanted.
A server for fetching server options have been added to the clients api/lib.py.

## Additional review information
I'm still not quite sure about the names of the options. That could be clearer, but I think this gets the points across.

## Testing notes:
1. Include the plugin built with this branch in a bundle
2. Set "Cache conflict resolution" settings.
3. Launch Harmony with a known project that would give the "Local cache of version exists" dialog on startup, and see if expected changes are reflected.
