### PR TITLE
Feature/harmony validate palette location

### DIFF
--- a/client/ayon_harmony/js/publish/CollectPalettes.js
+++ b/client/ayon_harmony/js/publish/CollectPalettes.js
@@ -10,19 +10,6 @@ if (typeof AyonHarmony === 'undefined') {
     include(AYON_HARMONY_JS.replace(/\\/g, "/"));
 }
 
-var JS_LOG_PATH = "C:/Users/normaal/Documents/YuanDev/AYON-Development-Workbench/ayon-harmony/LOG.txt";
-
-/**
- * Append a line to the shared log file.
- * @param {string} text
- */
-function writeJsLog(text) {
-    var file = new File(JS_LOG_PATH);
-    file.open(FileAccess.Append);
-    file.write(text + "\n");
-    file.close();
-}
-
 
 /**
  * Map a numeric PaletteObjectManager.Constants.Location value to a
@@ -49,6 +36,7 @@ function paletteLocationToStorage(location) {
     }
 }
 
+
 /**
  * @namespace
  * @classdesc CollectPalettes JS code.
@@ -66,25 +54,13 @@ CollectPalettes.prototype.getPalettes = function(local_only) {
 
     var palette_list = PaletteObjectManager.getScenePaletteList();
 
-    writeJsLog("@@@@@@@ getPalettes START");
-    writeJsLog("    local_only: " + local_only);
-    writeJsLog("    numPalettes: " + palette_list.numPalettes);
-
     var palettes = {};
     for(var i=0; i < palette_list.numPalettes; ++i) {
         var palette = palette_list.getPaletteByIndex(i);
-
-        var isExternal = (palette.location == PaletteObjectManager.Constants.Location.EXTERNAL);
-        var isSkipped = local_only && isExternal;
         var storage = paletteLocationToStorage(palette.location);
 
-        writeJsLog("    palette name: " + palette.getName());
-        writeJsLog("        location: " + palette.location + " (external: " + isExternal + ")");
-        writeJsLog("        storage: " + storage);
-        writeJsLog("        skipped: " + isSkipped);
-
         // if local_only is true, skip external palettes
-        if (isSkipped) {
+        if (local_only && palette.location == PaletteObjectManager.Constants.Location.EXTERNAL) {
             continue;
         }
 
@@ -93,8 +69,6 @@ CollectPalettes.prototype.getPalettes = function(local_only) {
             storage: storage
         };
     }
-
-    writeJsLog("@@@@@@@ getPalettes END - result: " + JSON.stringify(palettes));
 
     return palettes;
     

--- a/client/ayon_harmony/js/publish/CollectPalettes.js
+++ b/client/ayon_harmony/js/publish/CollectPalettes.js
@@ -10,6 +10,44 @@ if (typeof AyonHarmony === 'undefined') {
     include(AYON_HARMONY_JS.replace(/\\/g, "/"));
 }
 
+var JS_LOG_PATH = "C:/Users/normaal/Documents/YuanDev/AYON-Development-Workbench/ayon-harmony/LOG.txt";
+
+/**
+ * Append a line to the shared log file.
+ * @param {string} text
+ */
+function writeJsLog(text) {
+    var file = new File(JS_LOG_PATH);
+    file.open(FileAccess.Append);
+    file.write(text + "\n");
+    file.close();
+}
+
+
+/**
+ * Map a numeric PaletteObjectManager.Constants.Location value to a
+ * human-readable storage name ("scene", "environment", "job",
+ * "element", "external").
+ * @param {number} location
+ * @return {string}
+ */
+function paletteLocationToStorage(location) {
+    var Loc = PaletteObjectManager.Constants.Location;
+    switch (location) {
+        case Loc.ENVIRONMENT:
+            return "environment";
+        case Loc.JOB:
+            return "job";
+        case Loc.SCENE:
+            return "scene";
+        case Loc.ELEMENT:
+            return "element";
+        case Loc.EXTERNAL:
+            return "external";
+        default:
+            return "unknown";
+    }
+}
 
 /**
  * @namespace
@@ -28,20 +66,38 @@ CollectPalettes.prototype.getPalettes = function(local_only) {
 
     var palette_list = PaletteObjectManager.getScenePaletteList();
 
+    writeJsLog("@@@@@@@ getPalettes START");
+    writeJsLog("    local_only: " + local_only);
+    writeJsLog("    numPalettes: " + palette_list.numPalettes);
+
     var palettes = {};
     for(var i=0; i < palette_list.numPalettes; ++i) {
         var palette = palette_list.getPaletteByIndex(i);
-        
+
+        var isExternal = (palette.location == PaletteObjectManager.Constants.Location.EXTERNAL);
+        var isSkipped = local_only && isExternal;
+        var storage = paletteLocationToStorage(palette.location);
+
+        writeJsLog("    palette name: " + palette.getName());
+        writeJsLog("        location: " + palette.location + " (external: " + isExternal + ")");
+        writeJsLog("        storage: " + storage);
+        writeJsLog("        skipped: " + isSkipped);
+
         // if local_only is true, skip external palettes
-        if (local_only && palette.location == PaletteObjectManager.Constants.Location.EXTERNAL) {
+        if (isSkipped) {
             continue;
         }
-        
-        palettes[palette.getName()] = palette.id;
+
+        palettes[palette.getName()] = {
+            id: palette.id,
+            storage: storage
+        };
     }
 
-    return palettes;
-};
+    writeJsLog("@@@@@@@ getPalettes END - result: " + JSON.stringify(palettes));
 
+    return palettes;
+    
+};
 // add self to AYON Loaders
 AyonHarmony.Publish.CollectPalettes = new CollectPalettes();

--- a/client/ayon_harmony/js/publish/CollectPalettes.js
+++ b/client/ayon_harmony/js/publish/CollectPalettes.js
@@ -71,7 +71,7 @@ CollectPalettes.prototype.getPalettes = function(local_only) {
     }
 
     return palettes;
-    
 };
+
 // add self to AYON Loaders
 AyonHarmony.Publish.CollectPalettes = new CollectPalettes();

--- a/client/ayon_harmony/js/publish/ExtractPalette.js
+++ b/client/ayon_harmony/js/publish/ExtractPalette.js
@@ -10,6 +10,19 @@ if (typeof AyonHarmony === 'undefined') {
     include(AYON_HARMONY_JS.replace(/\\/g, "/"));
 }
 
+var JS_LOG_PATH = "C:/Users/normaal/Documents/YuanDev/AYON-Development-Workbench/ayon-harmony/LOG.txt";
+
+/**
+ * Append a line to the shared log file.
+ * @param {string} text
+ */
+function writeJsLog(text) {
+    var file = new File(JS_LOG_PATH);
+    file.open(FileAccess.Append);
+    file.write(text + "\n");
+    file.close();
+}
+
 /**
  * @namespace
  * @classdesc Code for extracting palettes.
@@ -24,9 +37,11 @@ var ExtractPalette = function() {};
  * @return  {array}  [paletteName, palettePath]
  */
 ExtractPalette.prototype.getPalette = function(paletteId) {
+    writeJsLog("@@@@@@@ extractpalette JS START");
     var palette_list = PaletteObjectManager.getScenePaletteList();
     var palette = palette_list.getPaletteById(paletteId);
     var palette_name = palette.getName();
+    writeJsLog("        palette.getPath() + '/' + palette.getName() + '.plt'" + palette.getPath() + '/' + palette.getName() + '.plt');
     return [
         palette_name,
         (palette.getPath() + '/' + palette.getName() + '.plt')

--- a/client/ayon_harmony/js/publish/ExtractPalette.js
+++ b/client/ayon_harmony/js/publish/ExtractPalette.js
@@ -10,7 +10,6 @@ if (typeof AyonHarmony === 'undefined') {
     include(AYON_HARMONY_JS.replace(/\\/g, "/"));
 }
 
-
 /**
  * @namespace
  * @classdesc Code for extracting palettes.
@@ -28,7 +27,6 @@ ExtractPalette.prototype.getPalette = function(paletteId) {
     var palette_list = PaletteObjectManager.getScenePaletteList();
     var palette = palette_list.getPaletteById(paletteId);
     var palette_name = palette.getName();
-    writeJsLog("        palette.getPath() + '/' + palette.getName() + '.plt'" + palette.getPath() + '/' + palette.getName() + '.plt');
     return [
         palette_name,
         (palette.getPath() + '/' + palette.getName() + '.plt')

--- a/client/ayon_harmony/js/publish/ExtractPalette.js
+++ b/client/ayon_harmony/js/publish/ExtractPalette.js
@@ -10,18 +10,6 @@ if (typeof AyonHarmony === 'undefined') {
     include(AYON_HARMONY_JS.replace(/\\/g, "/"));
 }
 
-var JS_LOG_PATH = "C:/Users/normaal/Documents/YuanDev/AYON-Development-Workbench/ayon-harmony/LOG.txt";
-
-/**
- * Append a line to the shared log file.
- * @param {string} text
- */
-function writeJsLog(text) {
-    var file = new File(JS_LOG_PATH);
-    file.open(FileAccess.Append);
-    file.write(text + "\n");
-    file.close();
-}
 
 /**
  * @namespace
@@ -37,7 +25,6 @@ var ExtractPalette = function() {};
  * @return  {array}  [paletteName, palettePath]
  */
 ExtractPalette.prototype.getPalette = function(paletteId) {
-    writeJsLog("@@@@@@@ extractpalette JS START");
     var palette_list = PaletteObjectManager.getScenePaletteList();
     var palette = palette_list.getPaletteById(paletteId);
     var palette_name = palette.getName();

--- a/client/ayon_harmony/plugins/publish/collect_palettes.py
+++ b/client/ayon_harmony/plugins/publish/collect_palettes.py
@@ -44,10 +44,11 @@ class CollectPalettes(pyblish.api.ContextPlugin):
         folder_path = context.data["folderPath"]
 
         product_base_type = "harmony.palette"
-        for name, palette_id in palettes.items():
+        for name, info in palettes.items():
             instance = context.create_instance(name)
             instance.data.update({
-                "id": palette_id,
+                "id": info["id"],
+                "paletteStorage": info["storage"],
                 "productType": product_base_type,
                 "productBaseType": product_base_type,
                 "family": product_base_type,

--- a/client/ayon_harmony/plugins/publish/help/validate_palette_location.xml
+++ b/client/ayon_harmony/plugins/publish/help/validate_palette_location.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+<error id="main">
+<title>Invalid palette location</title>
+<description>
+## Palette stored in an invalid location
+
+Palette '{palette_name}' is located in '{palette_location}', which is not allowed for publish.
+
+### How to repair?
+
+Please 'Clone' this palette at Scene level and 'Remove and Delete on Disk' the original palette manually.
+
+</description>
+</error>
+</root>

--- a/client/ayon_harmony/plugins/publish/validate_palette_location.py
+++ b/client/ayon_harmony/plugins/publish/validate_palette_location.py
@@ -1,0 +1,36 @@
+import pyblish.api
+
+from ayon_core.pipeline import OptionalPyblishPluginMixin
+from ayon_core.pipeline.publish import (
+    ValidateContentsOrder,
+    PublishXmlValidationError,
+)
+
+
+class ValidatePaletteLocation(
+    pyblish.api.InstancePlugin,
+    OptionalPyblishPluginMixin,
+):
+    """Validate that a palette is stored at scene level. Palettes stored at 'environment' or 'job' level are not versioned with the scene."""
+
+    label = "Validate Palette Location"
+    hosts = ["harmony"]
+    families = ["harmony.palette"]
+    order = ValidateContentsOrder
+    optional = True
+
+    invalid_storages = ["environment", "job"]
+
+    def process(self, instance):
+        if not self.is_active(instance.data):
+            return
+
+        storage = instance.data.get("paletteStorage")
+
+        if storage in self.invalid_storages:
+            msg = f"Found invalid palette location '{instance.name}' is stored at '{storage}'"
+            formatting_data = {
+                "palette_name": instance.name,
+                "palette_location": storage,
+            }
+            raise PublishXmlValidationError(self, msg, formatting_data=formatting_data)


### PR DESCRIPTION
## Changelog Description
Adds a new publish validator for Harmony that checks the palette location before publishing. This helps catch misplaced palettes , preventing publish errors.

## Additional review information
Environment palettes are not managed the same way as other scene-level palettes. When a workfile is incremented at publish , environment palettes end up pointing to (or depending on) an outdated version of the workfile, which causes inconsistencies. Because of this, palettes should not be saved in the environment location. This validator catches that case early and raises a clear error to the artist so they can move the palette before publishing.

## Testing notes:
1. Open a Harmony scene with a palette stored in envirenment or job.
2. Run the publish process twice.