### PR TITLE
Feature: Workfile Template Builder

### DIFF
--- a/client/ayon_harmony/api/TB_sceneOpened.js
+++ b/client/ayon_harmony/api/TB_sceneOpened.js
@@ -510,6 +510,51 @@ function start() {
         action.triggered.connect(self.onSetSceneSettings);
     }
 
+    self.onBuildWorkfileTemplate = function() {
+        app.ayonClient.send({
+            'module': 'ayon_harmony.api.workfile_template_builder',
+            'method': 'build_workfile_template',
+            'args': []
+        }, false);
+    };
+    if (app.ayonMenu == null) {
+        menu.addSeparator();
+        action = menu.addAction('Build Workfile Template');
+        action.triggered.connect(self.onBuildWorkfileTemplate);
+    }
+    self.onUpdateWorkfileTemplate = function() {
+        app.ayonClient.send({
+            'module': 'ayon_harmony.api.workfile_template_builder',
+            'method': 'update_workfile_template',
+            'args': []
+        }, false);
+    };
+    if (app.ayonMenu == null) {
+        action = menu.addAction('Update Workfile Template');
+        action.triggered.connect(self.onUpdateWorkfileTemplate);
+    }
+    self.onCreatePlaceholder = function() {
+        app.ayonClient.send({
+            'module': 'ayon_harmony.api.workfile_template_builder',
+            'method': 'create_placeholder',
+            'args': []
+        }, false);
+    };
+    if (app.ayonMenu == null) {
+        action = menu.addAction('Create PlaceHolder');
+        action.triggered.connect(self.onCreatePlaceholder);
+    }
+    self.onUpdatePlaceholder = function() {
+        app.ayonClient.send({
+            'module': 'ayon_harmony.api.workfile_template_builder',
+            'method': 'update_placeholder',
+            'args': []
+        }, false);
+    };
+    if (app.ayonMenu == null) {
+        action = menu.addAction('Update PlaceHolder');
+        action.triggered.connect(self.onUpdatePlaceholder);
+    }
     /**
       * Show Experimental dialog
       */

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -60,6 +60,7 @@ CREATE_PATH = os.path.join(PLUGINS_DIR, "create")
 INVENTORY_PATH = os.path.join(PLUGINS_DIR, "inventory")
 WORKFILE_BUILD_PATH = os.path.join(PLUGINS_DIR, "workfile_build")
 
+
 class HarmonyHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
     name = "harmony"
 

--- a/client/ayon_harmony/api/pipeline.py
+++ b/client/ayon_harmony/api/pipeline.py
@@ -21,8 +21,10 @@ from ayon_core.host import (
 from ayon_core.pipeline import (
     register_loader_plugin_path,
     register_creator_plugin_path,
+    register_workfile_build_plugin_path,
     deregister_loader_plugin_path,
     deregister_creator_plugin_path,
+    deregister_workfile_build_plugin_path,
     AVALON_CONTAINER_ID,
     AYON_CONTAINER_ID,
 )
@@ -56,7 +58,7 @@ PUBLISH_PATH = os.path.join(PLUGINS_DIR, "publish")
 LOAD_PATH = os.path.join(PLUGINS_DIR, "load")
 CREATE_PATH = os.path.join(PLUGINS_DIR, "create")
 INVENTORY_PATH = os.path.join(PLUGINS_DIR, "inventory")
-
+WORKFILE_BUILD_PATH = os.path.join(PLUGINS_DIR, "workfile_build")
 
 class HarmonyHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
     name = "harmony"
@@ -71,6 +73,7 @@ class HarmonyHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         pyblish.api.register_plugin_path(PUBLISH_PATH)
         register_loader_plugin_path(LOAD_PATH)
         register_creator_plugin_path(CREATE_PATH)
+        register_workfile_build_plugin_path(WORKFILE_BUILD_PATH)
 
         register_event_callback("application.launched", application_launch)
 
@@ -78,6 +81,7 @@ class HarmonyHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         pyblish.api.deregister_plugin_path(PUBLISH_PATH)
         deregister_loader_plugin_path(LOAD_PATH)
         deregister_creator_plugin_path(CREATE_PATH)
+        deregister_workfile_build_plugin_path(WORKFILE_BUILD_PATH)
 
     def open_workfile(self, filepath):
         return open_file(filepath)

--- a/client/ayon_harmony/api/workfile_template_builder.py
+++ b/client/ayon_harmony/api/workfile_template_builder.py
@@ -1,0 +1,503 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+import zipfile
+from pathlib import Path
+from typing import Any
+
+from qtpy import QtWidgets, QtCore
+
+from ayon_core.pipeline import registered_host
+from ayon_core.pipeline.workfile.workfile_template_builder import (
+    AbstractTemplateBuilder,
+    PlaceholderItem,
+    PlaceholderPlugin,
+)
+from ayon_core.tools.utils import show_message_dialog
+from ayon_core.tools.workfile_template_build import (
+    WorkfileBuildPlaceholderDialog,
+)
+from ayon_core import style
+
+import ayon_harmony.api as harmony
+
+
+class HarmonyTemplateBuilder(AbstractTemplateBuilder):
+    """Concrete implementation of AbstractTemplateBuilder for Toon Boom Harmony."""
+
+    def __init__(self, host):
+        super().__init__(host)
+        self._progress_dialog = None
+
+    def _show_progress(
+        self,
+        title: str,
+        label: str,
+        maximum: int = 0,
+    ) -> QtWidgets.QProgressDialog:
+        """Create, style, and immediately show a modal progress dialog.
+
+        Args:
+            title (str): Window title text.
+            label (str): Initial label text shown below the bar.
+            maximum (int): Bar maximum. 0 means indeterminate (busy spinner).
+
+        Returns:
+            QtWidgets.QProgressDialog: The visible dialog.
+        """
+        progress = QtWidgets.QProgressDialog(label, None, 0, maximum)
+        progress.setStyleSheet(style.load_stylesheet())
+        progress.setWindowTitle(title)
+        progress.setWindowModality(QtCore.Qt.WindowModal)
+        progress.setMinimumDuration(0)
+        progress.setCancelButton(None)
+        progress.show()
+        QtWidgets.QApplication.processEvents(
+            QtCore.QEventLoop.AllEvents, 50
+        )
+        return progress
+
+    def _update_progress(
+        self,
+        label: str | None = None,
+        value: int | None = None,
+    ) -> None:
+        """Update the active progress dialog and flush Qt events.
+
+        Args:
+            label (str | None): New label text, or None to leave unchanged.
+            value (int | None): New bar value, or None to leave unchanged.
+        """
+        if not self._progress_dialog:
+            return
+        if label is not None:
+            self._progress_dialog.setLabelText(label)
+        if value is not None:
+            self._progress_dialog.setValue(value)
+        QtWidgets.QApplication.processEvents(
+            QtCore.QEventLoop.AllEvents, 50
+        )
+
+    def import_template(self, path: str) -> bool:
+        """Import a Harmony template into the current scene.
+
+        Args:
+            path (str): Absolute path to the template .tpl folder.
+
+        Returns:
+            bool: True if the template loaded successfully, False otherwise.
+        """
+        sig = harmony.signature("paste")
+        func = """function %s(args)
+        {
+            var template_path = args[0];
+            var drag_object = copyPaste.pasteTemplateIntoGroup(template_path, "Top", 1);
+        }
+        %s
+        """ % (sig, sig)
+
+        harmony.send({"function": func, "args": [path]})
+        success = True
+        return success
+
+    def build_template(self, *args, **kwargs) -> None:
+        """Build the workfile template with a progress dialog.
+
+        Shows an indeterminate dialog for the full duration. The label
+        transitions through "Preparing..." → "Importing template..." →
+        "Populating placeholders..." via hooks in import_template().
+
+        Args:
+            *args: Forwarded to AbstractTemplateBuilder.build_template.
+            **kwargs: Forwarded to AbstractTemplateBuilder.build_template.
+        """
+        progress = self._show_progress(
+            title="Building Template",
+            label="Preparing...",
+            maximum=0,  # indeterminate -- duration not predictable
+        )
+        self._progress_dialog = progress
+        try:
+            super().build_template(*args, **kwargs)
+        finally:
+            self._progress_dialog = None
+            progress.close()
+
+    def rebuild_template(self) -> None:
+        """Rebuild all placeholders in the current scene with a progress dialog."""
+        placeholders = self.get_placeholders()
+        total = len(placeholders)
+        noun = "placeholder" if total == 1 else "placeholders"
+
+        progress = self._show_progress(
+            title="Updating Template",
+            label=f"Populating {total} {noun}...",
+            maximum=0,  # indeterminate
+        )
+        self._progress_dialog = progress
+        try:
+            super().rebuild_template()
+        finally:
+            self._progress_dialog = None
+            progress.close()
+
+
+class HarmonyPlaceholderPlugin(PlaceholderPlugin):
+    """Base Placeholder Plugin for Toon Boom Harmony.
+
+    Placeholder metadata is stored in two places simultaneously so that it
+    survives a Harmony template export/import round-trip:
+
+    BurnIn node is choosen cause it supports both a Peg and Output both of
+    which are relinked after the placeholder is filled. It also has a nice
+    text field to store the metadata.
+    """
+
+    attr_prefix: str = "AYON_placeholder_"
+
+    def get_placeholder_node_name(self, placeholder_data: dict) -> str:
+        return self.identifier.replace(".", "_")
+
+    def create_placeholder_node(self, node_name: str | None = None) -> str:
+        """Create a BurnIn node in Harmony to act as a placeholder.
+
+        Args:
+            node_name (str | None): Desired node name. Defaults to the plugin
+                identifier with dots replaced by underscores.
+
+        Returns:
+            str: The node identifier for the created BurnIn node.
+        """
+        name = node_name or self.identifier.replace(".", "_")
+        node_id = harmony.send({
+            "function": "AyonHarmonyAPI.createNodeContainer",
+            "args": [name, "BurnIn", False],
+        })["result"]
+        return node_id
+
+    def create_placeholder(self, placeholder_data: dict) -> None:
+        """Create a placeholder node and imprint it with placeholder metadata.
+
+        Args:
+            placeholder_data (dict): Placeholder configuration data including
+                loader name, product name, and filter settings.
+        """
+        node_name = self.get_placeholder_node_name(placeholder_data)
+        node_id = self.create_placeholder_node(node_name)
+
+        placeholder_data["plugin_identifier"] = self.identifier
+        self._imprint(node_id, placeholder_data)
+
+    def collect_scene_placeholders(self) -> list[str]:
+        """Collect all placeholder node identifiers from the current scene.
+
+        Returns:
+            list[str]: Node identifier strings for all matching placeholder
+                nodes found in the current scene.
+        """
+        placeholder_nodes = self.builder.get_shared_populate_data(
+            self.identifier
+        )
+
+        if placeholder_nodes is None:
+            scene_data = harmony.get_scene_data()
+            prefixed_key = self.attr_prefix + "plugin_identifier"
+            placeholder_nodes = []
+            found_node_ids: set[str] = set()
+
+            for node_id, node_data in scene_data.items():
+                if not isinstance(node_data, dict):
+                    continue
+
+                if (
+                    node_data.get(prefixed_key) == self.identifier
+                    or node_data.get("plugin_identifier") == self.identifier
+                ):
+                    placeholder_nodes.append(node_id)
+                    found_node_ids.add(node_id)
+
+            attr_placeholders = self._scan_burnin_nodes_for_placeholder_data()
+            for node_id, attr_data in attr_placeholders.items():
+                if node_id in found_node_ids:
+                    # Already present in the scene JSON; nothing to do.
+                    continue
+                if attr_data.get("plugin_identifier") != self.identifier:
+                    # Data belongs to a different plugin; skip.
+                    continue
+
+                self._imprint(node_id, attr_data)
+                placeholder_nodes.append(node_id)
+
+            self.builder.set_shared_populate_data(
+                self.identifier, placeholder_nodes
+            )
+
+        return placeholder_nodes
+
+    def collect_placeholders(self) -> list[PlaceholderItem]:
+        """Collect all AYON PlaceholderItems from the current Harmony scene.
+
+        Returns:
+            list[PlaceholderItem]: All placeholder items found in the scene,
+                each carrying the node identifier as ``scene_identifier`` and
+                the prefix-stripped metadata dict.
+        """
+        output = []
+        for node_id in self.collect_scene_placeholders():
+            placeholder_data = self._read(node_id)
+            output.append(PlaceholderItem(node_id, placeholder_data, self))
+        return output
+
+    def update_placeholder(
+        self,
+        placeholder_item: PlaceholderItem,
+        placeholder_data: dict,
+    ) -> None:
+        """Update an existing placeholder node's metadata and name.
+
+        Args:
+            placeholder_item (PlaceholderItem): The placeholder to update,
+                providing the current ``scene_identifier`` (node path).
+            placeholder_data (dict): The updated placeholder configuration.
+        """
+        old_node_id = placeholder_item.scene_identifier
+.
+        self._imprint(old_node_id, placeholder_data, update=True)
+
+        # Rename the physical node in Harmony.
+        new_name = self.get_placeholder_node_name(placeholder_data)
+        harmony.rename_node(old_node_id, new_name)
+
+        # Harmony node paths follow "<parentGroup>/<nodeName>".
+        parent_group = old_node_id.rsplit("/", 1)[0]
+        new_node_id = f"{parent_group}/{new_name}"
+
+        if old_node_id != new_node_id:
+            scene_data = harmony.get_scene_data()
+            if old_node_id in scene_data:
+                scene_data[new_node_id] = scene_data.pop(old_node_id)
+                harmony.set_scene_data(scene_data)
+
+    def delete_placeholder(self, placeholder: PlaceholderItem) -> None:
+        """Delete a placeholder node and its scene metadata from Harmony.
+
+        Args:
+            placeholder (PlaceholderItem): The placeholder to delete.
+        """
+        node_id = placeholder.scene_identifier
+
+        # Purge the metadata entry from the scene.
+        harmony.imprint(node_id, {}, remove=True)
+
+        # Physically remove the node from the Harmony scene.
+        harmony.delete_node(node_id)
+
+    def _imprint(
+        self,
+        node_id: str,
+        placeholder_data: dict,
+        update: bool = False,
+    ) -> None:
+        """Write placeholder_data into the AYON scene JSON and the node's printinfo.
+
+        Writing to both stores keeps them in sync:
+
+        - The **Scene** entry enables fast reads during normal operation.
+        - The **BurnIn ``printinfo``** entry survives template export/import,
+          acting as the authoritative source when the scene JSON entry is absent.
+
+        Args:
+            node_id (str): Node identifier used as the scene data JSON key.
+            placeholder_data (dict): Key/value pairs to imprint.
+            update (bool): Accepted for API compatibility; no-op in Harmony.
+        """
+        prefixed_data = {
+            f"{self.attr_prefix}{key}": value
+            for key, value in placeholder_data.items()
+        }
+        harmony.imprint(node_id, prefixed_data)
+
+        self._write_attr_data(node_id, placeholder_data)
+
+    def _read(self, node_id: str) -> dict[str, Any]:
+        """Read AYON placeholder metadata from the Harmony scene JSON.
+
+        Args:
+            node_id (str): Node identifier to read metadata for.
+
+        Returns:
+            dict[str, Any]: Placeholder configuration with prefix removed from
+                all keys.
+        """
+        data = harmony.read(node_id)
+
+        for key in list(data):
+            if key.startswith(self.attr_prefix):
+                value = data.pop(key)
+                data[key[len(self.attr_prefix):]] = value
+
+        return data
+
+    def _write_attr_data(self, node_id: str, data: dict) -> None:
+        """Serialise *data* as JSON and store it in the node's ``printinfo`` attribute.
+
+        ``node.setTextAttr`` writes to a named text attribute on a Harmony node.
+        The ``printinfo`` attribute is used here because it accepts arbitrary
+        freeform text
+
+        Args:
+            node_id (str): Full Harmony path of the BurnIn node to annotate.
+            data (dict): Placeholder configuration to serialise and store.
+        """
+        payload = json.dumps(data, separators=(",", ":"))
+
+        sig = harmony.signature("write_placeholder_attr")
+        func = """function %s(args)
+        {
+            node.setTextAttr(args[0], "printinfo", 1, args[1]);
+        }
+        %s
+        """ % (sig, sig)
+        harmony.send({"function": func, "args": [node_id, payload]})
+
+    def _scan_burnin_nodes_for_placeholder_data(self) -> dict[str, dict]:
+        """Scan every BurnIn node in the scene for embedded AYON placeholder data.
+
+        Returns:
+            dict[str, dict]: Mapping of Harmony node path to de-serialised
+                placeholder data for every BurnIn node carrying a parseable
+                AYON placeholder payload.
+        """
+        sig = harmony.signature("scan_burnin_placeholder_attrs")
+        # NOTE maybe add max-depth to this function as a failsafe
+        func = """function %s(args)
+        {
+            var result = {};
+
+            function scanGroup(group)
+            {
+                var nodeList = node.subNodes(group);
+                for (var i = 0; i < nodeList.length; i++) {
+                    var n = nodeList[i];
+
+                    // Only BurnIn nodes are used as AYON placeholders.
+                    if (node.type(n) === "BurnIn") {
+                        var attrVal = node.getTextAttr(n, 1, "printinfo");
+                        if (attrVal && attrVal.length > 0) {
+                            result[n] = attrVal;
+                        }
+                    }
+
+                    if (node.type(n) === "GROUP") {
+                        scanGroup(n);
+                    }
+                }
+            }
+
+            scanGroup("Top");
+            return result;
+        }
+        %s
+        """ % (sig, sig)
+
+        response = harmony.send({"function": func, "args": []})
+        raw: dict[str, str] = response.get("result") or {}
+
+        output: dict[str, dict] = {}
+        for node_id, attr_val in raw.items():
+            try:
+                output[node_id] = json.loads(attr_val)
+            except (ValueError, TypeError):
+                # printinfo contains non-JSON text; not an AYON placeholder.
+                continue
+
+        return output
+
+
+def build_workfile_template(*args, **kwargs) -> None:
+    """Build the workfile template in the current Harmony scene."""
+    builder = HarmonyTemplateBuilder(registered_host())
+    builder.build_template(*args, **kwargs)
+
+
+def update_workfile_template(*args) -> None:
+    """Re-populate all placeholders in the current Harmony scene."""
+    builder = HarmonyTemplateBuilder(registered_host())
+    builder.rebuild_template()
+
+
+def create_placeholder(*args) -> None:
+    """Open the AYON Workfile Build Placeholder dialog in Harmony."""
+    import time
+    from ayon_harmony.api.lib import ProcessContext
+
+    time.sleep(1)
+
+    host = registered_host()
+    builder = HarmonyTemplateBuilder(host)
+
+    def _show():
+        window = WorkfileBuildPlaceholderDialog(host, builder, parent=None)
+        window.exec_()
+
+    ProcessContext.execute_in_main_thread(_show)
+    return "nothing"
+
+
+def update_placeholder(*args) -> None:
+    """Open the placeholder dialog in update mode for the selected node."""
+    import time
+    from ayon_harmony.api.lib import ProcessContext
+
+    time.sleep(1)
+
+    host = registered_host()
+    builder = HarmonyTemplateBuilder(host)
+
+    def _show():
+        # get_placeholders() calls harmony.get_scene_data() internally.
+        placeholder_items_by_id = {
+            item.scene_identifier: item
+            for item in builder.get_placeholders()
+        }
+
+        selected_nodes = harmony.send({
+            "function": "selection.selectedNodes",
+            "args": [],
+        }).get("result") or []
+
+        placeholder_items = [
+            placeholder_items_by_id[node]
+            for node in selected_nodes
+            if node in placeholder_items_by_id
+        ]
+
+        if len(placeholder_items) == 0:
+            show_message_dialog(
+                "Workfile Placeholder Manager",
+                "Please select a placeholder node.",
+                "warning",
+                None,
+            )
+            return
+
+        if len(placeholder_items) > 1:
+            show_message_dialog(
+                "Workfile Placeholder Manager",
+                "Too many selected placeholder nodes."
+                "\nPlease select one placeholder node.",
+                "warning",
+                None,
+            )
+            return
+
+        placeholder_item = placeholder_items[0]
+        window = WorkfileBuildPlaceholderDialog(host, builder, parent=None)
+        window.set_update_mode(placeholder_item)
+        window.exec_()
+
+    ProcessContext.execute_in_main_thread(_show)
+    return "nothing"

--- a/client/ayon_harmony/api/workfile_template_builder.py
+++ b/client/ayon_harmony/api/workfile_template_builder.py
@@ -1,11 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
-import shutil
-import tempfile
-import zipfile
-from pathlib import Path
 from typing import Any
 
 from qtpy import QtWidgets, QtCore
@@ -26,7 +21,7 @@ import ayon_harmony.api as harmony
 
 
 class HarmonyTemplateBuilder(AbstractTemplateBuilder):
-    """Concrete implementation of AbstractTemplateBuilder for Toon Boom Harmony."""
+    """Concrete implementation of AbstractTemplateBuilder for TB Harmony."""
 
     def __init__(self, host):
         super().__init__(host)
@@ -90,7 +85,9 @@ class HarmonyTemplateBuilder(AbstractTemplateBuilder):
         func = """function %s(args)
         {
             var template_path = args[0];
-            var drag_object = copyPaste.pasteTemplateIntoGroup(template_path, "Top", 1);
+            var drag_object = copyPaste.pasteTemplateIntoGroup(
+                template_path, "Top", 1
+            );
         }
         %s
         """ % (sig, sig)
@@ -123,7 +120,7 @@ class HarmonyTemplateBuilder(AbstractTemplateBuilder):
             progress.close()
 
     def rebuild_template(self) -> None:
-        """Rebuild all placeholders in the current scene with a progress dialog."""
+        """Rebuild all placeholders in the current scene."""
         placeholders = self.get_placeholders()
         total = len(placeholders)
         noun = "placeholder" if total == 1 else "placeholders"
@@ -298,13 +295,14 @@ class HarmonyPlaceholderPlugin(PlaceholderPlugin):
         placeholder_data: dict,
         update: bool = False,
     ) -> None:
-        """Write placeholder_data into the AYON scene JSON and the node's printinfo.
+        """Write placeholder_data into the AYON scene and the node's printinfo.
 
         Writing to both stores keeps them in sync:
 
         - The **Scene** entry enables fast reads during normal operation.
         - The **BurnIn ``printinfo``** entry survives template export/import,
-          acting as the authoritative source when the scene JSON entry is absent.
+          acting as the authoritative source when the scene JSON entry is
+          absent.
 
         Args:
             node_id (str): Node identifier used as the scene data JSON key.
@@ -339,9 +337,9 @@ class HarmonyPlaceholderPlugin(PlaceholderPlugin):
         return data
 
     def _write_attr_data(self, node_id: str, data: dict) -> None:
-        """Serialise *data* as JSON and store it in the node's ``printinfo`` attribute.
+        """Serialise *data* as JSON and store it in the printinfo attribute.
 
-        ``node.setTextAttr`` writes to a named text attribute on a Harmony node.
+        ``node.setTextAttr`` writes to a named text attr on a Harmony node.
         The ``printinfo`` attribute is used here because it accepts arbitrary
         freeform text
 
@@ -361,7 +359,7 @@ class HarmonyPlaceholderPlugin(PlaceholderPlugin):
         harmony.send({"function": func, "args": [node_id, payload]})
 
     def _scan_burnin_nodes_for_placeholder_data(self) -> dict[str, dict]:
-        """Scan every BurnIn node in the scene for embedded AYON placeholder data.
+        """Scan every BurnIn node in the scene for AYON placeholder data.
 
         Returns:
             dict[str, dict]: Mapping of Harmony node path to de-serialised

--- a/client/ayon_harmony/api/workfile_template_builder.py
+++ b/client/ayon_harmony/api/workfile_template_builder.py
@@ -55,9 +55,7 @@ class HarmonyTemplateBuilder(AbstractTemplateBuilder):
         progress.setMinimumDuration(0)
         progress.setCancelButton(None)
         progress.show()
-        QtWidgets.QApplication.processEvents(
-            QtCore.QEventLoop.AllEvents, 50
-        )
+        QtWidgets.QApplication.processEvents(QtCore.QEventLoop.AllEvents, 50)
         return progress
 
     def _update_progress(
@@ -77,9 +75,7 @@ class HarmonyTemplateBuilder(AbstractTemplateBuilder):
             self._progress_dialog.setLabelText(label)
         if value is not None:
             self._progress_dialog.setValue(value)
-        QtWidgets.QApplication.processEvents(
-            QtCore.QEventLoop.AllEvents, 50
-        )
+        QtWidgets.QApplication.processEvents(QtCore.QEventLoop.AllEvents, 50)
 
     def import_template(self, path: str) -> bool:
         """Import a Harmony template into the current scene.
@@ -172,10 +168,12 @@ class HarmonyPlaceholderPlugin(PlaceholderPlugin):
             str: The node identifier for the created BurnIn node.
         """
         name = node_name or self.identifier.replace(".", "_")
-        node_id = harmony.send({
-            "function": "AyonHarmonyAPI.createNodeContainer",
-            "args": [name, "BurnIn", False],
-        })["result"]
+        node_id = harmony.send(
+            {
+                "function": "AyonHarmonyAPI.createNodeContainer",
+                "args": [name, "BurnIn", False],
+            }
+        )["result"]
         return node_id
 
     def create_placeholder(self, placeholder_data: dict) -> None:
@@ -264,7 +262,6 @@ class HarmonyPlaceholderPlugin(PlaceholderPlugin):
             placeholder_data (dict): The updated placeholder configuration.
         """
         old_node_id = placeholder_item.scene_identifier
-.
         self._imprint(old_node_id, placeholder_data, update=True)
 
         # Rename the physical node in Harmony.
@@ -337,7 +334,7 @@ class HarmonyPlaceholderPlugin(PlaceholderPlugin):
         for key in list(data):
             if key.startswith(self.attr_prefix):
                 value = data.pop(key)
-                data[key[len(self.attr_prefix):]] = value
+                data[key[len(self.attr_prefix) :]] = value
 
         return data
 
@@ -460,14 +457,18 @@ def update_placeholder(*args) -> None:
     def _show():
         # get_placeholders() calls harmony.get_scene_data() internally.
         placeholder_items_by_id = {
-            item.scene_identifier: item
-            for item in builder.get_placeholders()
+            item.scene_identifier: item for item in builder.get_placeholders()
         }
 
-        selected_nodes = harmony.send({
-            "function": "selection.selectedNodes",
-            "args": [],
-        }).get("result") or []
+        selected_nodes = (
+            harmony.send(
+                {
+                    "function": "selection.selectedNodes",
+                    "args": [],
+                }
+            ).get("result")
+            or []
+        )
 
         placeholder_items = [
             placeholder_items_by_id[node]

--- a/client/ayon_harmony/plugins/load/load_background.py
+++ b/client/ayon_harmony/plugins/load/load_background.py
@@ -230,6 +230,7 @@ class BackgroundLoader(load.LoaderPlugin):
     """Load images
     Stores the imported product in a container named after the product.
     """
+    label = "Load a background"
     product_base_types = {"background"}
     product_types = product_base_types
     representations = {"*"}

--- a/client/ayon_harmony/plugins/workfile_build/create_placeholder.py
+++ b/client/ayon_harmony/plugins/workfile_build/create_placeholder.py
@@ -1,4 +1,5 @@
 """Harmony Create Placeholder Plugin."""
+
 import ayon_harmony.api as harmony
 from ayon_core.pipeline.workfile.workfile_template_builder import (
     CreatePlaceholderItem,
@@ -20,9 +21,10 @@ class HarmonyPlaceholderCreatePlugin(
         """Populate a placeholder by running its configured Creator."""
         self.populate_create_placeholder(placeholder)
 
-    def repopulate_placeholder(self, placeholder: CreatePlaceholderItem) -> None:
-        """Re-populate an existing create placeholder (e.g. on workfile reopen).
-        """
+    def repopulate_placeholder(
+        self, placeholder: CreatePlaceholderItem
+    ) -> None:
+        """Re-populate an existing create placeholder (e.g. on workfile reopen)."""
         self.populate_create_placeholder(placeholder)
 
     def get_placeholder_options(self, options: dict | None = None) -> list:
@@ -52,10 +54,12 @@ class HarmonyPlaceholderCreatePlugin(
             str: The node identifier for the created READ node.
         """
         name = node_name or self.identifier.replace(".", "_")
-        return harmony.send({
-            "function": "AyonHarmonyAPI.createNodeContainer",
-            "args": [name, "BurnIn", False],
-        })["result"]
+        return harmony.send(
+            {
+                "function": "AyonHarmonyAPI.createNodeContainer",
+                "args": [name, "BurnIn", False],
+            }
+        )["result"]
 
     def collect_placeholders(self) -> list[CreatePlaceholderItem]:
         """Collect all create placeholder items from the current Harmony scene.

--- a/client/ayon_harmony/plugins/workfile_build/create_placeholder.py
+++ b/client/ayon_harmony/plugins/workfile_build/create_placeholder.py
@@ -1,0 +1,73 @@
+"""Harmony Create Placeholder Plugin."""
+import ayon_harmony.api as harmony
+from ayon_core.pipeline.workfile.workfile_template_builder import (
+    CreatePlaceholderItem,
+    PlaceholderCreateMixin,
+)
+
+from ayon_harmony.api.workfile_template_builder import HarmonyPlaceholderPlugin
+
+
+class HarmonyPlaceholderCreatePlugin(
+    HarmonyPlaceholderPlugin, PlaceholderCreateMixin
+):
+    """Workfile template plugin for Harmony "create placeholders"."""
+
+    identifier = "ayon.create.placeholder"
+    label = "Harmony Create"
+
+    def populate_placeholder(self, placeholder: CreatePlaceholderItem) -> None:
+        """Populate a placeholder by running its configured Creator."""
+        self.populate_create_placeholder(placeholder)
+
+    def repopulate_placeholder(self, placeholder: CreatePlaceholderItem) -> None:
+        """Re-populate an existing create placeholder (e.g. on workfile reopen).
+        """
+        self.populate_create_placeholder(placeholder)
+
+    def get_placeholder_options(self, options: dict | None = None) -> list:
+        """Return the UI option definitions for the placeholder dialog.
+
+        Args:
+            options (dict | None): Existing option values to pre-populate.
+
+        Returns:
+            list: Option widget definitions for WorkfileBuildPlaceholderDialog.
+        """
+        return self.get_create_plugin_options(options)
+
+    def get_placeholder_node_name(self, placeholder_data: dict) -> str:
+        """Return a Harmony-safe name for the create placeholder node.
+
+        Returns:
+            str: Name derived from the plugin identifier with dots replaced
+                by underscores.
+        """
+        return self.identifier.replace(".", "_")
+
+    def create_placeholder_node(self, node_name: str | None = None) -> str:
+        """Create a BurnIn node to act as the create placeholder.
+
+        Returns:
+            str: The node identifier for the created READ node.
+        """
+        name = node_name or self.identifier.replace(".", "_")
+        return harmony.send({
+            "function": "AyonHarmonyAPI.createNodeContainer",
+            "args": [name, "BurnIn", False],
+        })["result"]
+
+    def collect_placeholders(self) -> list[CreatePlaceholderItem]:
+        """Collect all create placeholder items from the current Harmony scene.
+
+        Returns:
+            list[CreatePlaceholderItem]: All create placeholder items found,
+                each wrapping the node identifier and its metadata.
+        """
+        output = []
+        for node_id in self.collect_scene_placeholders():
+            placeholder_data = self._read(node_id)
+            output.append(
+                CreatePlaceholderItem(node_id, placeholder_data, self)
+            )
+        return output

--- a/client/ayon_harmony/plugins/workfile_build/create_placeholder.py
+++ b/client/ayon_harmony/plugins/workfile_build/create_placeholder.py
@@ -24,7 +24,7 @@ class HarmonyPlaceholderCreatePlugin(
     def repopulate_placeholder(
         self, placeholder: CreatePlaceholderItem
     ) -> None:
-        """Re-populate an existing create placeholder (e.g. on workfile reopen)."""
+        """Re-populate an existing create placeholder."""
         self.populate_create_placeholder(placeholder)
 
     def get_placeholder_options(self, options: dict | None = None) -> list:

--- a/client/ayon_harmony/plugins/workfile_build/load_placeholder.py
+++ b/client/ayon_harmony/plugins/workfile_build/load_placeholder.py
@@ -14,8 +14,7 @@ from ayon_harmony.api.workfile_template_builder import HarmonyPlaceholderPlugin
 class HarmonyPlaceholderLoadPlugin(
     HarmonyPlaceholderPlugin, PlaceholderLoadMixin
 ):
-    """Workfile template plugin to create and populate Harmony load placeholders.
-    """
+    """Workfile template plugin to create and populate Harmony load placeholders."""
 
     identifier = "ayon.load.placeholder"
     label = "Harmony Load"
@@ -87,9 +86,7 @@ class HarmonyPlaceholderLoadPlugin(
         output = []
         for node_id in self.collect_scene_placeholders():
             placeholder_data = self._read(node_id)
-            output.append(
-                LoadPlaceholderItem(node_id, placeholder_data, self)
-            )
+            output.append(LoadPlaceholderItem(node_id, placeholder_data, self))
         return output
 
     def load_succeed(
@@ -117,11 +114,7 @@ class HarmonyPlaceholderLoadPlugin(
     def _resolve_container_node(self, container: dict | str) -> str:
         """Extract the Harmony node identifier from a loaded container."""
         if isinstance(container, dict):
-            return (
-                container.get("objectName")
-                or container.get("name")
-                or ""
-            )
+            return container.get("objectName") or container.get("name") or ""
         return str(container)
 
     def transfer_node_connections(
@@ -136,7 +129,6 @@ class HarmonyPlaceholderLoadPlugin(
             target_node (str): Full Harmony path of the loaded container node.
         """
         sig = harmony.signature()
-        # TODO Make this more readable
         func = """function %s(args)
         {
             var coord_x = node.coordX(args[0]);
@@ -145,20 +137,19 @@ class HarmonyPlaceholderLoadPlugin(
             
             var numIn = node.numberOfInputPorts(args[0]);
             for (var i = 0; i < numIn; i++) {
-            var src = node.srcNode(args[0], i);node.link(src, 0, args[1], i, true, true);}
+                var src = node.srcNode(args[0], i);
+                node.link(src, 0, args[1], i, true, true);
+            }
             var numOut = node.numberOfOutputPorts(args[0]);
             if (numOut != 0) {for (var i = 0; i < numOut; i++) {
-            var numLinked = node.numberOfOutputLinks(args[0], i);
-            for (var j = 0; j < numLinked; j++)
-            {var dst = node.dstNode(args[0], i, j);
-            node.link(args[1], i, dst, 0, true, true);}}}
+                var numLinked = node.numberOfOutputLinks(args[0], i);
+                for (var j = 0; j < numLinked; j++){
+                    var dst = node.dstNode(args[0], i, j);
+                    node.link(args[1], i, dst, 0, true, true);
+                    }
+                }
+            }
         }
         %s
         """ % (sig, sig)
-        harmony.send(
-            {
-                "function": func,
-                "args": [source_node, target_node]    
-            }
-        )
-
+        harmony.send({"function": func, "args": [source_node, target_node]})

--- a/client/ayon_harmony/plugins/workfile_build/load_placeholder.py
+++ b/client/ayon_harmony/plugins/workfile_build/load_placeholder.py
@@ -1,0 +1,164 @@
+"""Harmony Load Placeholder Plugin."""
+
+from __future__ import annotations
+
+import ayon_harmony.api as harmony
+from ayon_core.pipeline.workfile.workfile_template_builder import (
+    LoadPlaceholderItem,
+    PlaceholderLoadMixin,
+)
+
+from ayon_harmony.api.workfile_template_builder import HarmonyPlaceholderPlugin
+
+
+class HarmonyPlaceholderLoadPlugin(
+    HarmonyPlaceholderPlugin, PlaceholderLoadMixin
+):
+    """Workfile template plugin to create and populate Harmony load placeholders.
+    """
+
+    identifier = "ayon.load.placeholder"
+    label = "Harmony Load"
+
+    def get_placeholder_node_name(self, placeholder_data: dict) -> str:
+        """Return a Harmony-safe name for the load placeholder node.
+
+        Args:
+            placeholder_data (dict): Placeholder configuration data.
+
+        Returns:
+            str: Name in the form ``"ayon_load_placeholder_<productName>"``.
+        """
+        return "{}_{}".format(
+            self.identifier.replace(".", "_"),
+            placeholder_data["product_name"],
+        )
+
+    def create_placeholder(self, placeholder_data: dict) -> None:
+        """Create a load placeholder node and imprint it with metadata.
+
+        Args:
+            placeholder_data (dict): Placeholder configuration including
+                ``loader``, ``product_name``, and filter fields.
+        """
+        node_name = self.get_placeholder_node_name(placeholder_data)
+
+        loader_name: str = placeholder_data["loader"]
+        loaders_by_name = self.builder.get_loaders_by_name()
+        loader_class = loaders_by_name[loader_name]
+
+        if hasattr(loader_class, "create_load_placeholder_node"):
+            node_id = loader_class().create_load_placeholder_node(
+                node_name,
+                placeholder_data,
+            )
+        else:
+            node_id = self.create_placeholder_node(node_name)
+
+        placeholder_data["plugin_identifier"] = self.identifier
+        self._imprint(node_id, placeholder_data)
+
+    def populate_placeholder(self, placeholder: LoadPlaceholderItem) -> None:
+        """Populate a placeholder by loading the matching AYON product."""
+        self.populate_load_placeholder(placeholder)
+
+    def repopulate_placeholder(self, placeholder: LoadPlaceholderItem) -> None:
+        """Re-populate an existing placeholder (e.g. on workfile reopen)."""
+        self.populate_load_placeholder(placeholder)
+
+    def get_placeholder_options(self, options: dict | None = None) -> list:
+        """Return the UI option definitions for the placeholder dialog.
+
+        Args:
+            options (dict | None): Existing option values to pre-populate.
+
+        Returns:
+            list: Option widget definitions for the WorkfileBuildPlaceholderDialog.
+        """
+        return self.get_load_plugin_options(options)
+
+    def collect_placeholders(self) -> list[LoadPlaceholderItem]:
+        """Collect all load placeholder items from the current Harmony scene.
+
+        Returns:
+            list[LoadPlaceholderItem]: All load placeholder items found,
+                each wrapping the node identifier and its metadata.
+        """
+        output = []
+        for node_id in self.collect_scene_placeholders():
+            placeholder_data = self._read(node_id)
+            output.append(
+                LoadPlaceholderItem(node_id, placeholder_data, self)
+            )
+        return output
+
+    def load_succeed(
+        self,
+        placeholder: LoadPlaceholderItem,
+        container: dict | str,
+    ) -> None:
+        """Called after a product is successfully loaded for this placeholder.
+
+        Args:
+            placeholder (LoadPlaceholderItem): The placeholder that was
+                populated, providing its node identifier as scene_identifier.
+            container (dict | str): The container returned by the loader.
+                In Harmony this is the dict produced by harmony.containerise,
+                with the node identifier stored under "objectName".
+        """
+        placeholder_node = placeholder.scene_identifier
+        container_node = self._resolve_container_node(container)
+
+        if not container_node:
+            return
+
+        self.transfer_node_connections(placeholder_node, container_node)
+
+    def _resolve_container_node(self, container: dict | str) -> str:
+        """Extract the Harmony node identifier from a loaded container."""
+        if isinstance(container, dict):
+            return (
+                container.get("objectName")
+                or container.get("name")
+                or ""
+            )
+        return str(container)
+
+    def transfer_node_connections(
+        self,
+        source_node: str,
+        target_node: str,
+    ) -> None:
+        """Transfer all input and output connections from source to target node.
+
+        Args:
+            source_node (str): Full Harmony path of the placeholder node.
+            target_node (str): Full Harmony path of the loaded container node.
+        """
+        sig = harmony.signature()
+        # TODO Make this more readable
+        func = """function %s(args)
+        {
+            var coord_x = node.coordX(args[0]);
+            var coord_y = node.coordY(args[0]);
+            node.setCoord(args[1], coord_x, coord_y);
+            
+            var numIn = node.numberOfInputPorts(args[0]);
+            for (var i = 0; i < numIn; i++) {
+            var src = node.srcNode(args[0], i);node.link(src, 0, args[1], i, true, true);}
+            var numOut = node.numberOfOutputPorts(args[0]);
+            if (numOut != 0) {for (var i = 0; i < numOut; i++) {
+            var numLinked = node.numberOfOutputLinks(args[0], i);
+            for (var j = 0; j < numLinked; j++)
+            {var dst = node.dstNode(args[0], i, j);
+            node.link(args[1], i, dst, 0, true, true);}}}
+        }
+        %s
+        """ % (sig, sig)
+        harmony.send(
+            {
+                "function": func,
+                "args": [source_node, target_node]    
+            }
+        )
+

--- a/client/ayon_harmony/plugins/workfile_build/load_placeholder.py
+++ b/client/ayon_harmony/plugins/workfile_build/load_placeholder.py
@@ -14,7 +14,7 @@ from ayon_harmony.api.workfile_template_builder import HarmonyPlaceholderPlugin
 class HarmonyPlaceholderLoadPlugin(
     HarmonyPlaceholderPlugin, PlaceholderLoadMixin
 ):
-    """Workfile template plugin to create and populate Harmony load placeholders."""
+    """Workfile template plugin to create and populate load placeholders."""
 
     identifier = "ayon.load.placeholder"
     label = "Harmony Load"
@@ -72,7 +72,7 @@ class HarmonyPlaceholderLoadPlugin(
             options (dict | None): Existing option values to pre-populate.
 
         Returns:
-            list: Option widget definitions for the WorkfileBuildPlaceholderDialog.
+            list: Option widget definitions for WorkfileBuildPlaceholderDialog.
         """
         return self.get_load_plugin_options(options)
 
@@ -122,7 +122,7 @@ class HarmonyPlaceholderLoadPlugin(
         source_node: str,
         target_node: str,
     ) -> None:
-        """Transfer all input and output connections from source to target node.
+        """Transfer all input/output connections from source to target node.
 
         Args:
             source_node (str): Full Harmony path of the placeholder node.
@@ -134,7 +134,7 @@ class HarmonyPlaceholderLoadPlugin(
             var coord_x = node.coordX(args[0]);
             var coord_y = node.coordY(args[0]);
             node.setCoord(args[1], coord_x, coord_y);
-            
+
             var numIn = node.numberOfInputPorts(args[0]);
             for (var i = 0; i < numIn; i++) {
                 var src = node.srcNode(args[0], i);

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -8,6 +8,7 @@ from .templated_workfile_build import (
     TemplatedWorkfileBuildModel
 )
 
+
 class HarmonySettings(BaseSettingsModel):
     """Harmony Project Settings."""
 

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -4,7 +4,9 @@ from .imageio import HarmonyImageIOModel
 from .load_plugins import HarmonyLoadPlugins
 from .creator_plugins import HarmonyCreatePlugins
 from .publish_plugins import HarmonyPublishPlugins
-
+from .templated_workfile_build import (
+    TemplatedWorkfileBuildModel
+)
 
 class HarmonySettings(BaseSettingsModel):
     """Harmony Project Settings."""
@@ -24,6 +26,10 @@ class HarmonySettings(BaseSettingsModel):
     publish: HarmonyPublishPlugins = SettingsField(
         default_factory=HarmonyPublishPlugins,
         title="Publish plugins"
+    )
+    templated_workfile_build: TemplatedWorkfileBuildModel = SettingsField(
+        title="Templated Workfile Build",
+        default_factory=TemplatedWorkfileBuildModel
     )
 
 
@@ -132,5 +138,8 @@ DEFAULT_HARMONY_SETTING = {
             "replace_pngs": True,
             "exr_compression": "ZIP"
         },
+    },
+    "templated_workfile_build": {
+        "profiles": []
     }
 }

--- a/server/settings/templated_workfile_build.py
+++ b/server/settings/templated_workfile_build.py
@@ -1,0 +1,45 @@
+from ayon_server.settings import (
+    BaseSettingsModel,
+    SettingsField,
+    task_types_enum,
+    folder_types_enum,
+)
+
+
+class TemplatedWorkfileProfileModel(BaseSettingsModel):
+    task_types: list[str] = SettingsField(
+        default_factory=list,
+        title="Task types",
+        enum_resolver=task_types_enum
+    )
+    task_names: list[str] = SettingsField(
+        default_factory=list,
+        title="Task names"
+    )
+    folder_types: list[str] = SettingsField(
+        default_factory=list,
+        title="Folder Types",
+        enum_resolver=folder_types_enum
+    )
+    folder_paths: list[str] = SettingsField(
+        default_factory=list,
+        title="Folder paths"
+    )
+    path: str = SettingsField(
+        title="Path to template",
+        section="Template Configuration",
+    )
+    keep_placeholder: bool = SettingsField(
+        False,
+        title="Keep placeholders")
+    create_first_version: bool = SettingsField(
+        True,
+        title="Create first version"
+    )
+
+
+class TemplatedWorkfileBuildModel(BaseSettingsModel):
+    """Settings for templated workfile builder."""
+    profiles: list[TemplatedWorkfileProfileModel] = SettingsField(
+        default_factory=list
+    )

--- a/server/settings/templated_workfile_build.py
+++ b/server/settings/templated_workfile_build.py
@@ -8,38 +8,32 @@ from ayon_server.settings import (
 
 class TemplatedWorkfileProfileModel(BaseSettingsModel):
     task_types: list[str] = SettingsField(
-        default_factory=list,
-        title="Task types",
-        enum_resolver=task_types_enum
+        default_factory=list, title="Task types", enum_resolver=task_types_enum
     )
     task_names: list[str] = SettingsField(
-        default_factory=list,
-        title="Task names"
+        default_factory=list, title="Task names"
     )
     folder_types: list[str] = SettingsField(
         default_factory=list,
         title="Folder Types",
-        enum_resolver=folder_types_enum
+        enum_resolver=folder_types_enum,
     )
     folder_paths: list[str] = SettingsField(
-        default_factory=list,
-        title="Folder paths"
+        default_factory=list, title="Folder paths"
     )
     path: str = SettingsField(
         title="Path to template",
         section="Template Configuration",
     )
-    keep_placeholder: bool = SettingsField(
-        False,
-        title="Keep placeholders")
+    keep_placeholder: bool = SettingsField(False, title="Keep placeholders")
     create_first_version: bool = SettingsField(
-        True,
-        title="Create first version"
+        True, title="Create first version"
     )
 
 
 class TemplatedWorkfileBuildModel(BaseSettingsModel):
     """Settings for templated workfile builder."""
+
     profiles: list[TemplatedWorkfileProfileModel] = SettingsField(
         default_factory=list
     )


### PR DESCRIPTION
I've based it on how the template builder works in Houdini and kept mostly the same logic

Few pointers:
- Placeholder Node uses a BurnIn node, I choose this one because it has both input and output support. After the actual Load has done the links (PEG, Composite) and position in the node view are copied from the placeholder node. Also BurnIn had a good attribute to store data, as this needs to be on the node as scenedata gets lost when using Harmony Templates as an intermediate to build your workfile template.
- Template path needs to be pointed to an unzipped .tpl folder, in my testing I grouped my nodes in the nodeview, made a harmony template from the group, opened the template, ungrouped and saved. This way the hierarchy is flat and as you would expect when you work on setting up your template

update: draft removed, tested and linting fixed