### PR TITLE
Fix: PSD Import messes nodes layout organization

### DIFF
--- a/client/ayon_harmony/js/loaders/ImageLoader.js
+++ b/client/ayon_harmony/js/loaders/ImageLoader.js
@@ -81,16 +81,10 @@ PsdLoader.prototype.importPsd = function(psdPath) {
     var sceneRoot = doc.root;
     var psdNodes = sceneRoot.importPSD(psdPath);
 
-    // Gather nodes in view
+    // Order only the newly imported nodes (everything upstream of the PSD
+    // composite).
     var psdComp = psdNodes[psdNodes.length - 1];
-    var sceneComp = doc.$node("Top/Composite");
-    if (sceneComp) {
-        psdComp.linkOutNode(sceneComp);
-        sceneRoot.orderNodeView();
-        psdComp.unlinkOutNode(sceneComp);
-    } else {
-        sceneRoot.orderNodeView();
-    }
+    psdComp.orderAboveNodes();
 
     return psdNodes;
 };


### PR DESCRIPTION
## Changelog Description
Fix importing PSD into a scene with nodes.

## Additional review information
How it looks like now
<img width="1912" height="468" alt="image" src="https://github.com/user-attachments/assets/2c6bed85-2aca-4867-b09d-94011f8dea01" />


## Testing notes:
1. Load a template with a clean structure
2. Import a PSD image representation
