### PR TITLE
Feature/tracking files for texture palette

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "client/ayon_harmony/vendor/OpenHarmony"]
+	path = client/ayon_harmony/vendor/OpenHarmony
+	url = https://github.com/cfourney/OpenHarmony.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "client/ayon_harmony/vendor/OpenHarmony"]
-	path = client/ayon_harmony/vendor/OpenHarmony
-	url = https://github.com/cfourney/OpenHarmony.git

--- a/client/ayon_harmony/plugins/load/load_palette.py
+++ b/client/ayon_harmony/plugins/load/load_palette.py
@@ -5,6 +5,14 @@ from ayon_core.pipeline import load
 
 import ayon_harmony.api as harmony
 
+def _texture_dir(plt_path: Path) -> Path:
+    """Return the expected texture folder path next to a .plt file.
+
+    Convention: "<plt_stem>_textures" sitting alongside the .plt.
+    """
+    result = plt_path.with_name(plt_path.stem + "_textures")
+    return result
+
 
 class LinkPaletteLoader(load.LoaderPlugin):
     """Link a palette.
@@ -98,7 +106,8 @@ class LinkPaletteLoader(load.LoaderPlugin):
 class ImportPaletteLoader(LinkPaletteLoader):
     """Import a palette.
 
-    Copy the palette to the scene directory and link it.
+    Copy the palette (and its texture folder, if any) to the scene
+    directory and link it.
     """
 
     label = "Import Palette"
@@ -110,7 +119,8 @@ class ImportPaletteLoader(LinkPaletteLoader):
     def load_palette(self, palette_path: str) -> str:
         """Import the palette to the scene.
 
-        Copy the palette to the scene directory and link it.
+        Copy the palette (and its texture folder, if present) to the
+        scene directory and link it.
 
         Args:
             palette_path (str): Path to the palette.
@@ -122,13 +132,50 @@ class ImportPaletteLoader(LinkPaletteLoader):
             {"function": "scene.currentProjectPath"}
         )["result"]
 
-        dst = Path(
-            scene_path,
-            "palette-library",
-            Path(palette_path).name,
-        )
+        src_plt = Path(palette_path)
+        dst_plt = Path(scene_path, "palette-library", src_plt.name)
 
-        self.log.info(f"Copying palette to {dst}")
-        shutil.copy(palette_path, dst)
+        self.log.info(f"Copying palette to {dst_plt}")
+        shutil.copy(src_plt, dst_plt)
 
-        return super().load_palette(dst.as_posix())
+        src_textures = _texture_dir(src_plt)
+        if src_textures.is_dir():
+            dst_textures = _texture_dir(dst_plt)
+            self.log.info(f"Copying textures to {dst_textures}")
+            shutil.copytree(src_textures, dst_textures, dirs_exist_ok=True)
+        else:
+            self.log.debug(
+                f"No texture folder found next to {src_plt}, skipping."
+            )
+
+        result = super().load_palette(dst_plt.as_posix())
+        return result
+
+    def remove(self, container) -> int:
+        """Remove the imported palette from the scene.
+
+        Removes the Harmony palette reference, then deletes the local
+        copied .plt file and its texture folder from disk.
+
+        Args:
+            container (dict): Container data.
+
+        Returns:
+            int: Removed palette index.
+        """
+        removed_idx = super().remove(container)
+
+        local_plt = Path(container["nodes"][0])
+
+        if local_plt.is_file():
+            self.log.info(f"Deleting local palette file {local_plt}")
+            local_plt.unlink()
+        else:
+            self.log.warning(f"Local palette file not found: {local_plt}")
+
+        local_textures = _texture_dir(local_plt)
+        if local_textures.is_dir():
+            self.log.info(f"Deleting local texture folder {local_textures}")
+            shutil.rmtree(local_textures)
+            
+        return removed_idx

--- a/client/ayon_harmony/plugins/load/load_palette.py
+++ b/client/ayon_harmony/plugins/load/load_palette.py
@@ -120,9 +120,7 @@ class ImportPaletteLoader(LinkPaletteLoader):
         Returns:
             str: Palette ID.
         """
-        scene_path = harmony.send(
-            {"function": "scene.currentProjectPath"}
-        )["result"]
+        scene_path = harmony.send({"function": "scene.currentProjectPath"})["result"]
 
         source_plt = Path(palette_path)
         destination_plt = Path(scene_path, "palette-library", source_plt.name)
@@ -132,13 +130,13 @@ class ImportPaletteLoader(LinkPaletteLoader):
 
         source_textures = source_plt.with_name(source_plt.stem + "_textures")
         if source_textures.is_dir():
-            destination_textures = destination_plt.with_name(destination_plt.stem + "_textures")
+            destination_textures = destination_plt.with_name(
+                destination_plt.stem + "_textures"
+            )
             self.log.info(f"Copying textures to {destination_textures}")
             shutil.copytree(source_textures, destination_textures, dirs_exist_ok=True)
         else:
-            self.log.debug(
-                f"No texture folder found next to {source_plt}, skipping."
-            )
+            self.log.debug(f"No texture folder found next to {source_plt}, skipping.")
 
         result = super().load_palette(destination_plt.as_posix())
         return result
@@ -166,5 +164,5 @@ class ImportPaletteLoader(LinkPaletteLoader):
         if local_textures.is_dir():
             self.log.info(f"Deleting local texture folder {local_textures}")
             shutil.rmtree(local_textures)
-            
+
         return removed_plt

--- a/client/ayon_harmony/plugins/load/load_palette.py
+++ b/client/ayon_harmony/plugins/load/load_palette.py
@@ -5,14 +5,6 @@ from ayon_core.pipeline import load
 
 import ayon_harmony.api as harmony
 
-def _texture_dir(plt_path: Path) -> Path:
-    """Return the expected texture folder path next to a .plt file.
-
-    Convention: "<plt_stem>_textures" sitting alongside the .plt.
-    """
-    result = plt_path.with_name(plt_path.stem + "_textures")
-    return result
-
 
 class LinkPaletteLoader(load.LoaderPlugin):
     """Link a palette.
@@ -132,23 +124,23 @@ class ImportPaletteLoader(LinkPaletteLoader):
             {"function": "scene.currentProjectPath"}
         )["result"]
 
-        src_plt = Path(palette_path)
-        dst_plt = Path(scene_path, "palette-library", src_plt.name)
+        source_plt = Path(palette_path)
+        destination_plt = Path(scene_path, "palette-library", source_plt.name)
 
-        self.log.info(f"Copying palette to {dst_plt}")
-        shutil.copy(src_plt, dst_plt)
+        self.log.info(f"Copying palette to {destination_plt}")
+        shutil.copy(source_plt, destination_plt)
 
-        src_textures = _texture_dir(src_plt)
-        if src_textures.is_dir():
-            dst_textures = _texture_dir(dst_plt)
-            self.log.info(f"Copying textures to {dst_textures}")
-            shutil.copytree(src_textures, dst_textures, dirs_exist_ok=True)
+        source_textures = source_plt.with_name(source_plt.stem + "_textures")
+        if source_textures.is_dir():
+            destination_textures = destination_plt.with_name(destination_plt.stem + "_textures")
+            self.log.info(f"Copying textures to {destination_textures}")
+            shutil.copytree(source_textures, destination_textures, dirs_exist_ok=True)
         else:
             self.log.debug(
-                f"No texture folder found next to {src_plt}, skipping."
+                f"No texture folder found next to {source_plt}, skipping."
             )
 
-        result = super().load_palette(dst_plt.as_posix())
+        result = super().load_palette(destination_plt.as_posix())
         return result
 
     def remove(self, container) -> int:
@@ -163,7 +155,7 @@ class ImportPaletteLoader(LinkPaletteLoader):
         Returns:
             int: Removed palette index.
         """
-        removed_idx = super().remove(container)
+        removed_plt = super().remove(container)
 
         local_plt = Path(container["nodes"][0])
 
@@ -173,9 +165,9 @@ class ImportPaletteLoader(LinkPaletteLoader):
         else:
             self.log.warning(f"Local palette file not found: {local_plt}")
 
-        local_textures = _texture_dir(local_plt)
+        local_textures = local_plt.with_name(local_plt.stem + "_textures")
         if local_textures.is_dir():
             self.log.info(f"Deleting local texture folder {local_textures}")
             shutil.rmtree(local_textures)
             
-        return removed_idx
+        return removed_plt

--- a/client/ayon_harmony/plugins/load/load_palette.py
+++ b/client/ayon_harmony/plugins/load/load_palette.py
@@ -143,11 +143,8 @@ class ImportPaletteLoader(LinkPaletteLoader):
         result = super().load_palette(destination_plt.as_posix())
         return result
 
-    def remove(self, container) -> int:
-        """Remove the imported palette from the scene.
-
-        Removes the Harmony palette reference, then deletes the local
-        copied .plt file and its texture folder from disk.
+    def remove(self, container: dict) -> int:
+        """Remove the imported palette from the scene and their files.
 
         Args:
             container (dict): Container data.

--- a/client/ayon_harmony/plugins/load/load_palette.py
+++ b/client/ayon_harmony/plugins/load/load_palette.py
@@ -87,7 +87,7 @@ class LinkPaletteLoader(load.LoaderPlugin):
         harmony.send(
             {
                 "function": "AyonHarmony.movePaletteToIndex",
-                "args": [palette_path, palette_idx]
+                "args": [palette_path, palette_idx],
             }
         )
 
@@ -120,7 +120,9 @@ class ImportPaletteLoader(LinkPaletteLoader):
         Returns:
             str: Palette ID.
         """
-        scene_path = harmony.send({"function": "scene.currentProjectPath"})["result"]
+        scene_path = harmony.send({"function": "scene.currentProjectPath"})[
+            "result"
+        ]
 
         source_plt = Path(palette_path)
         destination_plt = Path(scene_path, "palette-library", source_plt.name)
@@ -134,9 +136,13 @@ class ImportPaletteLoader(LinkPaletteLoader):
                 destination_plt.stem + "_textures"
             )
             self.log.info(f"Copying textures to {destination_textures}")
-            shutil.copytree(source_textures, destination_textures, dirs_exist_ok=True)
+            shutil.copytree(
+                source_textures, destination_textures, dirs_exist_ok=True
+            )
         else:
-            self.log.debug(f"No texture folder found next to {source_plt}, skipping.")
+            self.log.debug(
+                f"No texture folder found next to {source_plt}, skipping."
+            )
 
         result = super().load_palette(destination_plt.as_posix())
         return result

--- a/client/ayon_harmony/plugins/publish/extract_palette.py
+++ b/client/ayon_harmony/plugins/publish/extract_palette.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Extract palette from Harmony."""
+
 import os
 import csv
 
@@ -22,8 +23,9 @@ class ExtractPalette(publish.Extractor):
         result = harmony.send(
             {
                 "function": f"AyonHarmony.Publish.{self_name}.getPalette",
-                "args": instance.data["id"]
-            })["result"]
+                "args": instance.data["id"],
+            }
+        )["result"]
 
         if not isinstance(result, list):
             self.log.error(f"Invalid reply: {result}")
@@ -39,7 +41,7 @@ class ExtractPalette(publish.Extractor):
 
         tmp_thumb_path = os.path.join(
             os.path.dirname(palette_file),
-            os.path.basename(palette_file).split(".plt")[0] + "_swatches.png"
+            os.path.basename(palette_file).split(".plt")[0] + "_swatches.png",
         )
         self.log.info(f"Temporary thumbnail path {tmp_thumb_path}")
 
@@ -55,33 +57,35 @@ class ExtractPalette(publish.Extractor):
                 thumbnail_path = self.create_palette_thumbnail(
                     palette_name, palette_version, palette_file, tmp_thumb_path
                 )
-                instance.data["representations"].append({
-                    "name": "thumbnail",
-                    "ext": "png",
-                    "files": os.path.basename(thumbnail_path),
-                    "stagingDir": os.path.dirname(thumbnail_path),
-                    "tags": ["thumbnail"]
-                })
-        
+                instance.data["representations"].append(
+                    {
+                        "name": "thumbnail",
+                        "ext": "png",
+                        "files": os.path.basename(thumbnail_path),
+                        "stagingDir": os.path.dirname(thumbnail_path),
+                        "tags": ["thumbnail"],
+                    }
+                )
+
         except OSError as e:
             # FIXME: this happens on Mac where PIL cannot access fonts
             # for some reason.
             self.log.warning("Thumbnail generation failed")
             self.log.warning(e)
-        except ValueError :
+        except ValueError:
             self.log.error("Unsupported palette type for thumbnail.")
 
-
-        instance.data["representations"].append({
-            "name": "plt",
-            "ext": "plt",
-            "files": os.path.basename(palette_file),
-            "stagingDir": os.path.dirname(palette_file)
-        })
+        instance.data["representations"].append(
+            {
+                "name": "plt",
+                "ext": "plt",
+                "files": os.path.basename(palette_file),
+                "stagingDir": os.path.dirname(palette_file),
+            }
+        )
 
         if palette_type == "texture" | palette_type == "mixed":
             self.add_texture_representations(instance, palette_file)
-
 
     def parse_palette_entries(self, palette_path: str) -> str:
         """Parse a .plt file and return its type + entries.
@@ -139,9 +143,9 @@ class ExtractPalette(publish.Extractor):
             palette_path (str): Path to the palette.
         """
         texture_dir = os.path.join(
-            os.path.dirname(palette_file), 
-            f"{os.path.basename(palette_file).split(".plt")[0]}_textures"
-            )
+            os.path.dirname(palette_file),
+            f"{os.path.basename(palette_file).split('.plt')[0]}_textures",
+        )
         if not os.path.isdir(texture_dir):
             texture_dir = None
 
@@ -163,19 +167,19 @@ class ExtractPalette(publish.Extractor):
 
         for tga_file in tga_files:
             repre_name = os.path.splitext(tga_file)[0]
-            instance.data["representations"].append({
-                "name": f"tga_{repre_name}",
-                "ext": "tga",
-                "files": tga_file,
-                "stagingDir": texture_dir,
-                "outputName": f"textures/{repre_name}",
-            })
+            instance.data["representations"].append(
+                {
+                    "name": f"tga_{repre_name}",
+                    "ext": "tga",
+                    "files": tga_file,
+                    "stagingDir": texture_dir,
+                    "outputName": f"textures/{repre_name}",
+                }
+            )
 
-    def create_palette_thumbnail(self,
-                                 palette_name,
-                                 palette_version,
-                                 palette_path,
-                                 dst_path):
+    def create_palette_thumbnail(
+        self, palette_name, palette_version, palette_path, dst_path
+    ):
         """Create thumbnail for palette file.
 
         Args:
@@ -190,21 +194,24 @@ class ExtractPalette(publish.Extractor):
         """
         colors = {}
 
-        with open(palette_path, newline='') as plt:
+        with open(palette_path, newline="") as plt:
             plt_parser = csv.reader(plt, delimiter=" ")
             for i, line in enumerate(plt_parser):
                 if i == 0:
                     continue
-                while ("" in line):
+                while "" in line:
                     line.remove("")
                 color_name = line[1].strip('"')
-                colors[color_name] = {"type": line[0],
-                                      "uuid": line[2],
-                                      "rgba": (int(line[3]),
-                                               int(line[4]),
-                                               int(line[5]),
-                                               int(line[6])),
-                                      }
+                colors[color_name] = {
+                    "type": line[0],
+                    "uuid": line[2],
+                    "rgba": (
+                        int(line[3]),
+                        int(line[4]),
+                        int(line[5]),
+                        int(line[6]),
+                    ),
+                }
             plt.close()
 
         img_pad_top = 80
@@ -216,12 +223,11 @@ class ExtractPalette(publish.Extractor):
         swatch_h = 50
 
         image_w = 800
-        image_h = (img_pad_top +
-                   (len(colors.keys()) *
-                    swatch_h) +
-                   (swatch_pad_top *
-                    len(colors.keys()))
-                   )
+        image_h = (
+            img_pad_top
+            + (len(colors.keys()) * swatch_h)
+            + (swatch_pad_top * len(colors.keys()))
+        )
 
         img = Image.new("RGBA", (image_w, image_h), "white")
 
@@ -241,10 +247,12 @@ class ExtractPalette(publish.Extractor):
         title_font = ImageFont.truetype("arial.ttf", 28)
         label_font = ImageFont.truetype("arial.ttf", 20)
 
-        draw.text((label_pad_name, 20),
-                  "{} (v{})".format(palette_name, palette_version),
-                  "black",
-                  font=title_font)
+        draw.text(
+            (label_pad_name, 20),
+            "{} (v{})".format(palette_name, palette_version),
+            "black",
+            font=title_font,
+        )
 
         for i, name in enumerate(colors):
             rgba = colors[name]["rgba"]
@@ -271,22 +279,45 @@ class ExtractPalette(publish.Extractor):
             #         fill=rgba, outline=(0, 0, 0), width=2)
             # else:
 
-            draw.rectangle((
-                swatch_pad_left,  # upper left x
-                img_pad_top + swatch_pad_top + (i * swatch_h),  # upper left y
-                swatch_pad_left + (swatch_w * 2),  # lower right x
-                img_pad_top + swatch_h + (i * swatch_h)),  # lower right y
-                fill=rgba, outline=(0, 0, 0), width=2)
+            draw.rectangle(
+                (
+                    swatch_pad_left,  # upper left x
+                    img_pad_top
+                    + swatch_pad_top
+                    + (i * swatch_h),  # upper left y
+                    swatch_pad_left + (swatch_w * 2),  # lower right x
+                    img_pad_top + swatch_h + (i * swatch_h),
+                ),  # lower right y
+                fill=rgba,
+                outline=(0, 0, 0),
+                width=2,
+            )
 
-            draw.text((label_pad_name, img_pad_top + (i * swatch_h) + swatch_pad_top + (swatch_h / 4)),  # noqa: E501
-                      name,
-                      "black",
-                      font=label_font)
+            draw.text(
+                (
+                    label_pad_name,
+                    img_pad_top
+                    + (i * swatch_h)
+                    + swatch_pad_top
+                    + (swatch_h / 4),
+                ),  # noqa: E501
+                name,
+                "black",
+                font=label_font,
+            )
 
-            draw.text((label_pad_rgb, img_pad_top + (i * swatch_h) + swatch_pad_top + (swatch_h / 4)),  # noqa: E501
-                      str(rgba),
-                      "black",
-                      font=label_font)
+            draw.text(
+                (
+                    label_pad_rgb,
+                    img_pad_top
+                    + (i * swatch_h)
+                    + swatch_pad_top
+                    + (swatch_h / 4),
+                ),  # noqa: E501
+                str(rgba),
+                "black",
+                font=label_font,
+            )
 
         draw = ImageDraw.Draw(img)
 

--- a/client/ayon_harmony/plugins/publish/extract_palette.py
+++ b/client/ayon_harmony/plugins/publish/extract_palette.py
@@ -8,6 +8,8 @@ from PIL import Image, ImageDraw, ImageFont
 import ayon_harmony.api as harmony
 from ayon_core.pipeline import publish
 
+log_path = r"C:\Users\normaal\Documents\YuanDev\AYON-Development-Workbench\ayon-harmony\LOG.txt"
+
 
 class ExtractPalette(publish.Extractor):
     """Extract palette."""
@@ -30,54 +32,116 @@ class ExtractPalette(publish.Extractor):
             raise AssertionError("Invalid reply from server.")
         palette_name = result[0]
         palette_file = result[1]
-        self.log.info(f"Got palette named {palette_name} "
-                      f"and file {palette_file}.")
+        self.log.info(
+            f"Got palette named {palette_name} and file {palette_file}."
+        )
 
-        tmp_thumb_path = os.path.join(os.path.dirname(palette_file),
-                                      os.path.basename(palette_file)
-                                      .split(".plt")[0] + "_swatches.png"
-                                      )
+        palette_type = self._parse_palette_entries(palette_file)
+        self.log.info(f"Detected palette type: {palette_type}")
+
+        tmp_thumb_path = os.path.join(
+            os.path.dirname(palette_file),
+            os.path.basename(palette_file).split(".plt")[0] + "_swatches.png"
+        )
         self.log.info(f"Temporary thumbnail path {tmp_thumb_path}")
 
         palette_version = str(instance.data.get("version")).zfill(3)
-
         self.log.info(f"Palette version {palette_version}")
 
         if not instance.data.get("representations"):
             instance.data["representations"] = []
 
         try:
-            thumbnail_path = self.create_palette_thumbnail(palette_name,
-                                                           palette_version,
-                                                           palette_file,
-                                                           tmp_thumb_path)
+            if palette_type == "solid":
+                thumbnail_path = self.create_palette_thumbnail(
+                    palette_name, palette_version, palette_file, tmp_thumb_path
+                )
+                instance.data["representations"].append({
+                    "name": "thumbnail",
+                    "ext": "png",
+                    "files": os.path.basename(thumbnail_path),
+                    "stagingDir": os.path.dirname(thumbnail_path),
+                    "tags": ["thumbnail"]
+                })
+                with open(log_path, "a") as f:
+                    f.write(f"    thumbnail_path: {thumbnail_path}\n")
+        
         except OSError as e:
             # FIXME: this happens on Mac where PIL cannot access fonts
             # for some reason.
             self.log.warning("Thumbnail generation failed")
             self.log.warning(e)
-        except ValueError:
+            with open(log_path, "a") as f:
+                f.write(f"    !!! Thumbnail generation failed (OSError): {e}\n")
+        except ValueError as e:
             self.log.error("Unsupported palette type for thumbnail.")
+            with open(log_path, "a") as f:
+                f.write(f"    !!! Unsupported palette type for thumbnail: {e}\n")
 
-        else:
-            thumbnail = {
-                "name": "thumbnail",
-                "ext": "png",
-                "files": os.path.basename(thumbnail_path),
-                "stagingDir": os.path.dirname(thumbnail_path),
-                "tags": ["thumbnail"]
-            }
 
-            instance.data["representations"].append(thumbnail)
 
-        representation = {
+        instance.data["representations"].append({
             "name": "plt",
             "ext": "plt",
             "files": os.path.basename(palette_file),
             "stagingDir": os.path.dirname(palette_file)
-        }
+        })
 
-        instance.data["representations"].append(representation)
+        if palette_type == "texture":
+            self.add_texture_representations(instance, palette_file)
+
+
+    def _parse_palette_entries(self, palette_path):
+        """Parse a .plt file and return its type + entries.
+
+        Returns:
+            tuple(str, list[dict]): palette type ("solid", "texture",
+                "mixed" or "empty") and the parsed entries in file order.
+        """
+        types_found = set()
+
+        with open(palette_path, newline="") as plt:
+            plt_parser = csv.reader(plt, delimiter=" ")
+            for i, line in enumerate(plt_parser):
+                if i == 0:
+                    continue
+                while "" in line:
+                    line.remove("")
+                if not line:
+                    continue
+
+                entry_type = line[0]
+
+                if entry_type == "Solid":
+                    types_found.add(entry_type)
+                elif entry_type == "Texture":
+                    types_found.add(entry_type)
+                elif len(line) == 1:
+                    self.log.debug(
+                        f"Skipping folder/group marker line: {line[0]}"
+                    )
+                else:
+                    self.log.warning(
+                        f"Unsupported palette entry type: {entry_type}"
+                    )
+
+        if types_found == {"Solid"}:
+            palette_type = "solid"
+        elif types_found == {"Texture"}:
+            palette_type = "texture"
+        elif types_found:
+            palette_type = "mixed"
+            self.log.warning(f"Mixed entry types in palette: {types_found}")
+        else:
+            palette_type = "empty"
+
+        with open(log_path, "a") as f:
+            f.write(
+                f"    _parse_palette_entries -> type={palette_type}, "
+                f"types_found={types_found}\n"
+            )
+
+        return palette_type
 
     def create_palette_thumbnail(self,
                                  palette_name,
@@ -105,9 +169,6 @@ class ExtractPalette(publish.Extractor):
                     continue
                 while ("" in line):
                     line.remove("")
-                # self.log.debug(line)
-                if line[0] not in ["Solid"]:
-                    raise ValueError("Unsupported palette type.")
                 color_name = line[1].strip('"')
                 colors[color_name] = {"type": line[0],
                                       "uuid": line[2],
@@ -203,3 +264,43 @@ class ExtractPalette(publish.Extractor):
 
         img.save(dst_path)
         return dst_path
+
+
+    def add_texture_representations(self, instance, palette_file):
+        """Find and publish the .tga files sitting next to the .plt.
+
+        Expects a flat folder named "<palette_stem>_texture" or
+        "<palette_stem>_textures" next to the .plt file.
+        """
+        texture_dir = os.path.join(
+            os.path.dirname(palette_file), 
+            f"{os.path.basename(palette_file).split(".plt")[0]}_textures"
+            )
+        if not os.path.isdir(texture_dir):
+            texture_dir = None
+
+        if not texture_dir:
+            self.log.warning(
+                f"No texture folder found next to {palette_file} "
+            )
+            return
+
+        tga_files = sorted(
+            f for f in os.listdir(texture_dir) if f.lower().endswith(".tga")
+        )
+
+        if not tga_files:
+            self.log.warning(f"No .tga files found in {texture_dir}")
+            return
+
+        self.log.info(f"Found {len(tga_files)} texture files in {texture_dir}")
+
+        for tga_file in tga_files:
+            repre_name = os.path.splitext(tga_file)[0]
+            instance.data["representations"].append({
+                "name": f"tga_{repre_name}",
+                "ext": "tga",
+                "files": tga_file,
+                "stagingDir": texture_dir,
+                "outputName": f"textures/{repre_name}",
+            })

--- a/client/ayon_harmony/plugins/publish/extract_palette.py
+++ b/client/ayon_harmony/plugins/publish/extract_palette.py
@@ -8,8 +8,6 @@ from PIL import Image, ImageDraw, ImageFont
 import ayon_harmony.api as harmony
 from ayon_core.pipeline import publish
 
-log_path = r"C:\Users\normaal\Documents\YuanDev\AYON-Development-Workbench\ayon-harmony\LOG.txt"
-
 
 class ExtractPalette(publish.Extractor):
     """Extract palette."""
@@ -36,7 +34,7 @@ class ExtractPalette(publish.Extractor):
             f"Got palette named {palette_name} and file {palette_file}."
         )
 
-        palette_type = self._parse_palette_entries(palette_file)
+        palette_type = self.parse_palette_entries(palette_file)
         self.log.info(f"Detected palette type: {palette_type}")
 
         tmp_thumb_path = os.path.join(
@@ -46,6 +44,7 @@ class ExtractPalette(publish.Extractor):
         self.log.info(f"Temporary thumbnail path {tmp_thumb_path}")
 
         palette_version = str(instance.data.get("version")).zfill(3)
+
         self.log.info(f"Palette version {palette_version}")
 
         if not instance.data.get("representations"):
@@ -63,21 +62,14 @@ class ExtractPalette(publish.Extractor):
                     "stagingDir": os.path.dirname(thumbnail_path),
                     "tags": ["thumbnail"]
                 })
-                with open(log_path, "a") as f:
-                    f.write(f"    thumbnail_path: {thumbnail_path}\n")
         
         except OSError as e:
             # FIXME: this happens on Mac where PIL cannot access fonts
             # for some reason.
             self.log.warning("Thumbnail generation failed")
             self.log.warning(e)
-            with open(log_path, "a") as f:
-                f.write(f"    !!! Thumbnail generation failed (OSError): {e}\n")
-        except ValueError as e:
+        except ValueError :
             self.log.error("Unsupported palette type for thumbnail.")
-            with open(log_path, "a") as f:
-                f.write(f"    !!! Unsupported palette type for thumbnail: {e}\n")
-
 
 
         instance.data["representations"].append({
@@ -87,16 +79,15 @@ class ExtractPalette(publish.Extractor):
             "stagingDir": os.path.dirname(palette_file)
         })
 
-        if palette_type == "texture":
+        if palette_type == "texture" | palette_type == "mixed":
             self.add_texture_representations(instance, palette_file)
 
 
-    def _parse_palette_entries(self, palette_path):
+    def parse_palette_entries(self, palette_path):
         """Parse a .plt file and return its type + entries.
 
         Returns:
-            tuple(str, list[dict]): palette type ("solid", "texture",
-                "mixed" or "empty") and the parsed entries in file order.
+            str: palette type ("solid", "texture")
         """
         types_found = set()
 
@@ -131,17 +122,48 @@ class ExtractPalette(publish.Extractor):
             palette_type = "texture"
         elif types_found:
             palette_type = "mixed"
-            self.log.warning(f"Mixed entry types in palette: {types_found}")
         else:
             palette_type = "empty"
 
-        with open(log_path, "a") as f:
-            f.write(
-                f"    _parse_palette_entries -> type={palette_type}, "
-                f"types_found={types_found}\n"
-            )
-
         return palette_type
+
+    def add_texture_representations(self, instance, palette_file):
+        """Find and publish the .tga files sitting next to the .plt.
+
+        Expects a flat folder named "<palette_stem>_textures" next to the .plt file.
+        """
+        texture_dir = os.path.join(
+            os.path.dirname(palette_file), 
+            f"{os.path.basename(palette_file).split(".plt")[0]}_textures"
+            )
+        if not os.path.isdir(texture_dir):
+            texture_dir = None
+
+        if not texture_dir:
+            self.log.warning(
+                f"No texture folder found next to {palette_file} "
+            )
+            return
+
+        tga_files = sorted(
+            f for f in os.listdir(texture_dir) if f.lower().endswith(".tga")
+        )
+
+        if not tga_files:
+            self.log.warning(f"No .tga files found in {texture_dir}")
+            return
+
+        self.log.info(f"Found {len(tga_files)} texture files in {texture_dir}")
+
+        for tga_file in tga_files:
+            repre_name = os.path.splitext(tga_file)[0]
+            instance.data["representations"].append({
+                "name": f"tga_{repre_name}",
+                "ext": "tga",
+                "files": tga_file,
+                "stagingDir": texture_dir,
+                "outputName": f"textures/{repre_name}",
+            })
 
     def create_palette_thumbnail(self,
                                  palette_name,
@@ -264,43 +286,3 @@ class ExtractPalette(publish.Extractor):
 
         img.save(dst_path)
         return dst_path
-
-
-    def add_texture_representations(self, instance, palette_file):
-        """Find and publish the .tga files sitting next to the .plt.
-
-        Expects a flat folder named "<palette_stem>_texture" or
-        "<palette_stem>_textures" next to the .plt file.
-        """
-        texture_dir = os.path.join(
-            os.path.dirname(palette_file), 
-            f"{os.path.basename(palette_file).split(".plt")[0]}_textures"
-            )
-        if not os.path.isdir(texture_dir):
-            texture_dir = None
-
-        if not texture_dir:
-            self.log.warning(
-                f"No texture folder found next to {palette_file} "
-            )
-            return
-
-        tga_files = sorted(
-            f for f in os.listdir(texture_dir) if f.lower().endswith(".tga")
-        )
-
-        if not tga_files:
-            self.log.warning(f"No .tga files found in {texture_dir}")
-            return
-
-        self.log.info(f"Found {len(tga_files)} texture files in {texture_dir}")
-
-        for tga_file in tga_files:
-            repre_name = os.path.splitext(tga_file)[0]
-            instance.data["representations"].append({
-                "name": f"tga_{repre_name}",
-                "ext": "tga",
-                "files": tga_file,
-                "stagingDir": texture_dir,
-                "outputName": f"textures/{repre_name}",
-            })

--- a/client/ayon_harmony/plugins/publish/extract_palette.py
+++ b/client/ayon_harmony/plugins/publish/extract_palette.py
@@ -83,8 +83,11 @@ class ExtractPalette(publish.Extractor):
             self.add_texture_representations(instance, palette_file)
 
 
-    def parse_palette_entries(self, palette_path):
+    def parse_palette_entries(self, palette_path: str) -> str:
         """Parse a .plt file and return its type + entries.
+
+        Args:
+            palette_path (str): Path to the palette.
 
         Returns:
             str: palette type ("solid", "texture")
@@ -127,10 +130,13 @@ class ExtractPalette(publish.Extractor):
 
         return palette_type
 
-    def add_texture_representations(self, instance, palette_file):
+    def add_texture_representations(self, instance, palette_file: str):
         """Find and publish the .tga files sitting next to the .plt.
 
         Expects a flat folder named "<palette_stem>_textures" next to the .plt file.
+
+        Args:
+            palette_path (str): Path to the palette.
         """
         texture_dir = os.path.join(
             os.path.dirname(palette_file), 

--- a/client/ayon_harmony/plugins/publish/extract_palette.py
+++ b/client/ayon_harmony/plugins/publish/extract_palette.py
@@ -137,7 +137,7 @@ class ExtractPalette(publish.Extractor):
     def add_texture_representations(self, instance, palette_file: str):
         """Find and publish the .tga files sitting next to the .plt.
 
-        Expects a flat folder named "<palette_stem>_textures" next to the .plt file.
+        Expects a flat folder named "<palette_stem>_textures" next to the .plt.
 
         Args:
             palette_path (str): Path to the palette.


### PR DESCRIPTION
## Changelog Description
Adds support for publishing texture-based palettes in Harmony. The extractor now detects palette type (color, texture, or mixed) and automatically publishes associated .tga texture files as representations alongside the .plt file.

## Additional review information
Until now, the extractor assumed all palettes were "color" type and always ignored the .tga textures, which broke on texture-based palettes when linked or imported to a scene. The texture palette need the .tga to function.

## Testing notes:
Publish a scene with a mixed or texture palette.
Link or load the published palette back into a scene.
Verify if the .plt and its associated .tga texture files are correctly loaded.