### PR TITLE
Feature/harmony validate palette location

### DIFF
--- a/client/ayon_harmony/plugins/publish/validate_palette_location.py
+++ b/client/ayon_harmony/plugins/publish/validate_palette_location.py
@@ -11,7 +11,11 @@ class ValidatePaletteLocation(
     pyblish.api.InstancePlugin,
     OptionalPyblishPluginMixin,
 ):
-    """Validate that a palette is stored at scene level. Palettes stored at 'environment' or 'job' level are not versioned with the scene."""
+    """
+    Validate that a palette is stored at scene level. 
+    
+    Palettes stored at 'environment' or 'job' level are not versioned with the scene.
+    """
 
     label = "Validate Palette Location"
     hosts = ["harmony"]
@@ -28,9 +32,14 @@ class ValidatePaletteLocation(
         storage = instance.data.get("paletteStorage")
 
         if storage in self.invalid_storages:
-            msg = f"Found invalid palette location '{instance.name}' is stored at '{storage}'"
+            msg = (
+                f"Found invalid palette location '{instance.name}' "
+                f"is stored at '{storage}'"
+            )
             formatting_data = {
                 "palette_name": instance.name,
                 "palette_location": storage,
             }
-            raise PublishXmlValidationError(self, msg, formatting_data=formatting_data)
+            raise PublishXmlValidationError(
+                self, msg, formatting_data=formatting_data
+            )

--- a/client/ayon_harmony/plugins/publish/validate_palette_location.py
+++ b/client/ayon_harmony/plugins/publish/validate_palette_location.py
@@ -14,7 +14,7 @@ class ValidatePaletteLocation(
     """
     Validate that a palette is stored at scene level.
 
-    Palettes stored at 'environment' or 'job' level 
+    Palettes stored at 'environment' or 'job' level
     are not versioned with the scene.
     """
 

--- a/client/ayon_harmony/plugins/publish/validate_palette_location.py
+++ b/client/ayon_harmony/plugins/publish/validate_palette_location.py
@@ -12,9 +12,10 @@ class ValidatePaletteLocation(
     OptionalPyblishPluginMixin,
 ):
     """
-    Validate that a palette is stored at scene level. 
-    
-    Palettes stored at 'environment' or 'job' level are not versioned with the scene.
+    Validate that a palette is stored at scene level.
+
+    Palettes stored at 'environment' or 'job' level 
+    are not versioned with the scene.
     """
 
     label = "Validate Palette Location"


### PR DESCRIPTION
## Changelog Description
This PR is created to resolve the linting problems encountered in an another branch which doesn't contain at all client/ayon_harmony/plugins/publish/validate_palette_location.py but the runner is still pointing toward it. 

<img width="1235" height="1013" alt="image" src="https://github.com/user-attachments/assets/d9acbb80-d99b-44c4-ac8d-8353cc198724" />
