### PR TITLE
Enhancement: Ignore frames directory when publishing workfile

### DIFF
--- a/client/ayon_harmony/plugins/publish/extract_workfile.py
+++ b/client/ayon_harmony/plugins/publish/extract_workfile.py
@@ -27,7 +27,7 @@ class ExtractWorkfile(publish.Extractor):
             src = fr"\\?\{src}"
             filepath = fr"\\?\{filepath}"
         self.log.info(f"Copying to {filepath}")
-        shutil.copytree(src, filepath)
+        shutil.copytree(src, filepath, ignore=shutil.ignore_patterns("frames*"))
 
         # Prep representation.
         shutil.make_archive(

--- a/client/ayon_harmony/plugins/publish/extract_workfile.py
+++ b/client/ayon_harmony/plugins/publish/extract_workfile.py
@@ -27,7 +27,9 @@ class ExtractWorkfile(publish.Extractor):
             src = fr"\\?\{src}"
             filepath = fr"\\?\{filepath}"
         self.log.info(f"Copying to {filepath}")
-        shutil.copytree(src, filepath, ignore=shutil.ignore_patterns("frames*"))
+        shutil.copytree(
+            src, filepath, ignore=shutil.ignore_patterns("frames*")
+        )
 
         # Prep representation.
         shutil.make_archive(


### PR DESCRIPTION
## Changelog Description
The `frames` directory that is generated in Harmony is only useful for preview and doesn't need to be packed with the rest of the workfile. By excluding it when the workfile is published, the amount of transiting data can be reduced without impacting functionality.

## Testing notes:
1. Publish a workfile.
2. Look inside the published workfile zip.
3. No `frames` directory.