### PR TITLE
Chore: Update base classes

### DIFF
--- a/client/ayon_harmony/api/plugin.py
+++ b/client/ayon_harmony/api/plugin.py
@@ -207,7 +207,6 @@ class HarmonyRenderCreator(HarmonyCreator):
 
     It creates new Composite type node from which it is rendered.
     """
-    product_type = "render"
 
     node_type = "COMPOSITE"
     # should node be auto connected to main Composite node for Harmony Advanced

--- a/client/ayon_harmony/api/plugin.py
+++ b/client/ayon_harmony/api/plugin.py
@@ -92,6 +92,7 @@ class HarmonyCreator(Creator, HarmonyCreatorBase):
     If the selection is used, the selected nodes will be connected to the
     created node.
     """
+    skip_discovery = True
 
     settings_category = "harmony"
 
@@ -207,6 +208,7 @@ class HarmonyRenderCreator(HarmonyCreator):
 
     It creates new Composite type node from which it is rendered.
     """
+    skip_discovery = True
 
     node_type = "COMPOSITE"
     # should node be auto connected to main Composite node for Harmony Advanced
@@ -331,12 +333,11 @@ class HarmonyRenderCreator(HarmonyCreator):
 
 
 class HarmonyAutoCreator(HarmonyCreatorBase, AutoCreator):
-
+    skip_discovery = True
     settings_category = "harmony"
     enabled = True
 
     def create(self):
-
         variant = None
         if self.default_variants:
             variant = self.default_variants[0]

--- a/client/ayon_harmony/api/plugin.py
+++ b/client/ayon_harmony/api/plugin.py
@@ -1,3 +1,4 @@
+from abc import abstractmethod
 import collections
 import re
 
@@ -187,8 +188,9 @@ class HarmonyCreator(Creator, HarmonyCreatorBase):
             }
         )
 
+    @abstractmethod
     def product_impl(self, name, instance_data: dict, pre_create_data: dict):
-        raise NotImplementedError
+        pass
 
     def get_pre_create_attr_defs(self):
         output = [

--- a/client/ayon_harmony/plugins/create/create_render.py
+++ b/client/ayon_harmony/plugins/create/create_render.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 """Create render node."""
 import ayon_harmony.api as harmony
-from ayon_harmony.api import plugin
+from ayon_harmony.api.plugin import HarmonyRenderCreator
 
 
-class CreateRender(plugin.HarmonyRenderCreator):
+class CreateRender(HarmonyRenderCreator):
     """Composite node for publishing renders."""
 
     identifier = "io.ayon.creators.harmony.render"


### PR DESCRIPTION
## Changelog Description
Mark base classes to be skipped during discovery, remove `product_type` from render base class and mark `product_impl` as abstractmethod.

## Testing notes:
1. Base classes are not discovered.
2. All create plugins that should be discovered are discovered.