### PR TITLE
Added Settings for ValidatePaletteLocation

### DIFF
--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -136,6 +136,11 @@ DEFAULT_HARMONY_SETTING = {
             "optional": True,
             "active": True
         },
+        "ValidatePaletteLocation": {
+            "enabled": False,
+            "optional": True,
+            "active": True
+        },
         "ExtractConvertToEXR": {
             "enabled": False,
             "replace_pngs": True,

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -50,6 +50,13 @@ class ValidateInstancePlugin(BaseSettingsModel):
     active: bool = SettingsField(True, title="Active")
 
 
+class ValidatePaletteLocationPlugin(BaseSettingsModel):
+    """Validate if palette location is inside  in the workfile."""
+    enabled: bool = False
+    optional: bool = SettingsField(False, title="Optional")
+    active: bool = SettingsField(True, title="Active")
+
+
 def compression_enum():
     return [
         {"value": "ZIP", "label": "ZIP"},
@@ -130,6 +137,11 @@ class HarmonyPublishPlugins(BaseSettingsModel):
     ValidateInstance: ValidateInstancePlugin = SettingsField(
         title="Validate Instance",
         default_factory=ValidateInstancePlugin,
+    )
+
+    ValidatePaletteLocation: ValidatePaletteLocationPlugin = SettingsField(
+        title="Validate Instance",
+        default_factory=ValidatePaletteLocationPlugin,
     )
 
     ExtractConvertToEXR: ExtractConvertToEXRModel = SettingsField(

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -140,7 +140,7 @@ class HarmonyPublishPlugins(BaseSettingsModel):
     )
 
     ValidatePaletteLocation: ValidatePaletteLocationPlugin = SettingsField(
-        title="Validate Instance",
+        title="Validate Palette Location",
         default_factory=ValidatePaletteLocationPlugin,
     )
 


### PR DESCRIPTION
## Changelog Description
Added Setting to control `ValidatePaletteLocation`. By default it is disabled as it seems that Environment Palette could be used only in Harmony Server (?) product

Testing Notes:
---------------
- check that `Validate Palette Location` is disabled
- try to publish and check that `Validate Palette Location` plugin is not triggered
