### PR TITLE
Fix: Headless for local workfile dialog

### DIFF
--- a/client/ayon_harmony/api/lib.py
+++ b/client/ayon_harmony/api/lib.py
@@ -611,7 +611,7 @@ def launch_zip_file(filepath):
 
     # Unzip the scene file and get the .xstage path
     try:
-        scene_path = unzip_scene_file(filepath)
+        scene_path = unzip_scene_file(filepath, headless=is_headless_mode_enabled())
     except Exception as e:
         print(f"Error unzipping scene file: {e}")
         ProcessContext.server.stop()

--- a/client/ayon_harmony/api/lib.py
+++ b/client/ayon_harmony/api/lib.py
@@ -611,7 +611,10 @@ def launch_zip_file(filepath):
 
     # Unzip the scene file and get the .xstage path
     try:
-        scene_path = unzip_scene_file(filepath, headless=is_headless_mode_enabled())
+        scene_path = unzip_scene_file(
+            filepath,
+            headless=is_headless_mode_enabled()
+        )
     except Exception as e:
         print(f"Error unzipping scene file: {e}")
         ProcessContext.server.stop()


### PR DESCRIPTION
## Changelog Description
Don't show local workfile version dialog when in headless mode.

## Testing notes:
1. Open a workfile
2. Save as and quit
3. Enable headless mode
4. Open the same workfile
